### PR TITLE
Restore code highlighting with conditional CSS loading

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,7 +1,10 @@
 const { DateTime } = require("luxon");
 const { minify } = require("html-minifier-terser");
+const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 
 module.exports = function (eleventyConfig) {
+  // Add syntax highlighting plugin
+  eleventyConfig.addPlugin(syntaxHighlight);
   // HTML minification transform
   eleventyConfig.addTransform("htmlmin", function (content) {
     if ((this.page.outputPath || "").endsWith(".html")) {
@@ -85,6 +88,13 @@ module.exports = function (eleventyConfig) {
     // Ensure url starts with /
     const cleanUrl = url.startsWith("/") ? url : `/${url}`;
     return `${cleanBase}${cleanUrl}`;
+  });
+
+  // Filter to detect if content has code blocks
+  eleventyConfig.addFilter("hasCodeBlocks", function (content) {
+    if (!content) return false;
+    // Check for code blocks with language classes or highlight classes
+    return /<pre[^>]*><code[^>]*class="[^"]*language-|<pre[^>]*class="[^"]*highlight/.test(content);
   });
 
   // Configure markdown

--- a/.prettierignore
+++ b/.prettierignore
@@ -58,3 +58,4 @@ src/js/boomerang-2.js
 
 # CSS files handled by different minification process
 src/css/main.css
+src/css/syntax-highlighting.css

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "tollmanz.com",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2"
+      },
       "devDependencies": {
         "@11ty/eleventy": "3.1.2",
         "backblaze-b2": "1.7.1",
@@ -140,6 +143,19 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-plugin-syntaxhighlight": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-5.0.2.tgz",
+      "integrity": "sha512-T6xVVRDJuHlrFMHbUiZkHjj5o1IlLzZW+1IL9eUsyXFU7rY2ztcYhZew/64vmceFFpQwzuSfxQOXxTJYmKkQ+A==",
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.30.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2011,6 +2027,15 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/proxy-from-env": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,9 @@
       "name": "tollmanz.com",
       "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "@11ty/eleventy-plugin-syntaxhighlight": "5.0.2"
-      },
       "devDependencies": {
         "@11ty/eleventy": "3.1.2",
+        "@11ty/eleventy-plugin-syntaxhighlight": "5.0.2",
         "backblaze-b2": "1.7.1",
         "chalk": "5.6.2",
         "dotenv": "17.2.2",
@@ -153,6 +151,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-5.0.2.tgz",
       "integrity": "sha512-T6xVVRDJuHlrFMHbUiZkHjj5o1IlLzZW+1IL9eUsyXFU7rY2ztcYhZew/64vmceFFpQwzuSfxQOXxTJYmKkQ+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prismjs": "^1.30.0"
@@ -2033,6 +2032,7 @@
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
       "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2"
+        "@11ty/eleventy-plugin-syntaxhighlight": "5.0.2"
       },
       "devDependencies": {
         "@11ty/eleventy": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "devDependencies": {
     "@11ty/eleventy": "3.1.2",
+    "@11ty/eleventy-plugin-syntaxhighlight": "5.0.2",
     "backblaze-b2": "1.7.1",
     "chalk": "5.6.2",
     "dotenv": "17.2.2",
@@ -25,8 +26,5 @@
     "markdown-it": "14.1.0",
     "mime-types": "2.1.35",
     "prettier": "3.6.2"
-  },
-  "dependencies": {
-    "@11ty/eleventy-plugin-syntaxhighlight": "5.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "markdown-it": "14.1.0",
     "mime-types": "2.1.35",
     "prettier": "3.6.2"
+  },
+  "dependencies": {
+    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "prettier": "3.6.2"
   },
   "dependencies": {
-    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2"
+    "@11ty/eleventy-plugin-syntaxhighlight": "5.0.2"
   }
 }

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -11,6 +11,9 @@
   <meta name="description" content="{{ description or site.description }}">
 
   <link href='/css/main.css' rel="stylesheet" type='text/css'>
+  {% if content | hasCodeBlocks %}
+  <link href='/css/syntax-highlighting.css' rel="stylesheet" type='text/css'>
+  {% endif %}
 
   <link rel="canonical" href="{{ site.url }}{{ page.url }}">
   <link rel="sitemap" type="application/xml" href="/sitemap.xml">

--- a/src/css/syntax-highlighting.css
+++ b/src/css/syntax-highlighting.css
@@ -4,7 +4,7 @@
 pre[class*="language-"] {
   background: #F8F8F8;
   color: #414141;
-  line-height: 1.5;
+  line-height: 1.0;
   margin-bottom: 30px;
   padding: 8px 12px;
   overflow-x: auto;

--- a/src/css/syntax-highlighting.css
+++ b/src/css/syntax-highlighting.css
@@ -1,0 +1,278 @@
+/* Syntax highlighting styles */
+.highlight {
+  background: #F8F8F8;
+  color: #e4322e;
+  line-height: 18px;
+}
+
+.highlight code {
+  font-size: 16px;
+  line-height: 20px;
+}
+
+.highlight .c {
+  color: #999988;
+  font-style: italic;
+}
+
+.highlight .err {
+  color: #a61717;
+  background-color: #e3d2d2;
+}
+
+.highlight .k {
+  color: #a79d00;
+  font-weight: normal;
+}
+
+.highlight .o {
+  color: #849a22;
+  font-weight: bold;
+}
+
+.highlight .cm {
+  color: #999988;
+  font-style: italic;
+}
+
+.highlight .cp {
+  color: #dc322f;
+  font-weight: normal;
+}
+
+.highlight .c1 {
+  color: #999988;
+  font-style: italic;
+}
+
+.highlight .cs {
+  color: #999999;
+  font-weight: bold;
+  font-style: italic;
+}
+
+.highlight .gd {
+  color: #000000;
+  background-color: #fdd;
+}
+
+.highlight .gd .x {
+  color: #000000;
+  background-color: #faa;
+}
+
+.highlight .ge {
+  color: #000000;
+  font-style: italic;
+}
+
+.highlight .gr {
+  color: #a00;
+}
+
+.highlight .gh {
+  color: #999999;
+}
+
+.highlight .gi {
+  color: #000000;
+  background-color: #dfd;
+}
+
+.highlight .gi .x {
+  color: #000000;
+  background-color: #aaffaa;
+}
+
+.highlight .go {
+  color: #888888;
+}
+
+.highlight .gp {
+  color: #555555;
+}
+
+.highlight .gs {
+  font-weight: bold;
+}
+
+.highlight .gu {
+  color: #aaaaaa;
+}
+
+.highlight .gt {
+  color: #aa0000;
+}
+
+.highlight .kc {
+  color: #000000;
+  font-weight: bold;
+}
+
+.highlight .kd {
+  color: #000000;
+  font-weight: bold;
+}
+
+.highlight .kp {
+  color: #000000;
+  font-weight: bold;
+}
+
+.highlight .kr {
+  color: #000000;
+  font-weight: bold;
+}
+
+.highlight .kt {
+  color: #445588;
+  font-weight: bold;
+}
+
+.highlight .m {
+  color: #099;
+}
+
+.highlight .s {
+  color: #d14;
+}
+
+.highlight .na {
+  color: #657b83;
+}
+
+.highlight .nb {
+  color: #0086B3;
+}
+
+.highlight .nc {
+  color: #445588;
+  font-weight: bold;
+}
+
+.highlight .no {
+  color: teal;
+}
+
+.highlight .ni {
+  color: purple;
+}
+
+.highlight .ne {
+  color: #990000;
+  font-weight: bold;
+}
+
+.highlight .nf {
+  color: #657b83;
+  font-weight: normal;
+}
+
+.highlight .nn {
+  color: #555;
+}
+
+.highlight .nt {
+  color: navy;
+}
+
+.highlight .nv {
+  color: #258ad1;
+}
+
+.highlight .ow {
+  color: #000000;
+  font-weight: bold;
+}
+
+.highlight .w {
+  color: #bbb;
+}
+
+.highlight .mf {
+  color: #099;
+}
+
+.highlight .mh {
+  color: #099;
+}
+
+.highlight .mi {
+  color: #4cc0cb;
+}
+
+.highlight .mo {
+  color: #099;
+}
+
+.highlight .sb {
+  color: #d14;
+}
+
+.highlight .sc {
+  color: #d14;
+}
+
+.highlight .sd {
+  color: #d14;
+}
+
+.highlight .s2 {
+  color: #d14;
+}
+
+.highlight .se {
+  color: #d14;
+}
+
+.highlight .sh {
+  color: #d14;
+}
+
+.highlight .si {
+  color: #d14;
+}
+
+.highlight .sx {
+  color: #d14;
+}
+
+.highlight .sr {
+  color: #009926;
+}
+
+.highlight .s1 {
+  color: #4cc0cb;
+}
+
+.highlight .ss {
+  color: #990073;
+}
+
+.highlight .bp {
+  color: #999;
+}
+
+.highlight .vc {
+  color: teal;
+}
+
+.highlight .vg {
+  color: teal;
+}
+
+.highlight .vi {
+  color: teal;
+}
+
+.highlight .il {
+  color: #099;
+}
+
+.highlight .nx {
+  color: #687b89;
+}
+
+.highlight .x {
+  color: #258bd2;
+}

--- a/src/css/syntax-highlighting.css
+++ b/src/css/syntax-highlighting.css
@@ -1,278 +1,135 @@
-/* Syntax highlighting styles */
-.highlight {
+/* Syntax highlighting styles for token-based markup */
+
+/* Base code block styling */
+pre[class*="language-"] {
   background: #F8F8F8;
-  color: #e4322e;
-  line-height: 18px;
+  color: #414141;
+  line-height: 1.5;
+  margin-bottom: 30px;
+  padding: 8px 12px;
+  overflow-x: auto;
+  border-top: 1px solid #DDD;
+  border-bottom: 1px solid #DDD;
 }
 
-.highlight code {
+code[class*="language-"] {
+  font-family: 'Ubuntu Mono', monospace;
   font-size: 16px;
-  line-height: 20px;
+  line-height: 1.25;
 }
 
-.highlight .c {
+/* Token-based syntax highlighting */
+
+/* Comments */
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
   color: #999988;
   font-style: italic;
 }
 
-.highlight .err {
-  color: #a61717;
-  background-color: #e3d2d2;
+/* Punctuation */
+.token.punctuation {
+  color: #999999;
 }
 
-.highlight .k {
-  color: #a79d00;
-  font-weight: normal;
+/* Properties, tags, boolean, number, constant, symbol, deleted */
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #4cc0cb;
 }
 
-.highlight .o {
+/* Selectors, attributes, strings, chars, built-ins, inserted */
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #d14;
+}
+
+/* Operators, entities, url, language-css .string, style .string, variables */
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
   color: #849a22;
   font-weight: bold;
 }
 
-.highlight .cm {
-  color: #999988;
-  font-style: italic;
-}
-
-.highlight .cp {
-  color: #dc322f;
+/* Keywords, at-rules, important */
+.token.keyword,
+.token.atrule,
+.token.attr-value,
+.token.important {
+  color: #a79d00;
   font-weight: normal;
 }
 
-.highlight .c1 {
-  color: #999988;
-  font-style: italic;
-}
-
-.highlight .cs {
-  color: #999999;
-  font-weight: bold;
-  font-style: italic;
-}
-
-.highlight .gd {
-  color: #000000;
-  background-color: #fdd;
-}
-
-.highlight .gd .x {
-  color: #000000;
-  background-color: #faa;
-}
-
-.highlight .ge {
-  color: #000000;
-  font-style: italic;
-}
-
-.highlight .gr {
-  color: #a00;
-}
-
-.highlight .gh {
-  color: #999999;
-}
-
-.highlight .gi {
-  color: #000000;
-  background-color: #dfd;
-}
-
-.highlight .gi .x {
-  color: #000000;
-  background-color: #aaffaa;
-}
-
-.highlight .go {
-  color: #888888;
-}
-
-.highlight .gp {
-  color: #555555;
-}
-
-.highlight .gs {
-  font-weight: bold;
-}
-
-.highlight .gu {
-  color: #aaaaaa;
-}
-
-.highlight .gt {
-  color: #aa0000;
-}
-
-.highlight .kc {
-  color: #000000;
-  font-weight: bold;
-}
-
-.highlight .kd {
-  color: #000000;
-  font-weight: bold;
-}
-
-.highlight .kp {
-  color: #000000;
-  font-weight: bold;
-}
-
-.highlight .kr {
-  color: #000000;
-  font-weight: bold;
-}
-
-.highlight .kt {
-  color: #445588;
-  font-weight: bold;
-}
-
-.highlight .m {
-  color: #099;
-}
-
-.highlight .s {
-  color: #d14;
-}
-
-.highlight .na {
-  color: #657b83;
-}
-
-.highlight .nb {
-  color: #0086B3;
-}
-
-.highlight .nc {
-  color: #445588;
-  font-weight: bold;
-}
-
-.highlight .no {
-  color: teal;
-}
-
-.highlight .ni {
-  color: purple;
-}
-
-.highlight .ne {
-  color: #990000;
-  font-weight: bold;
-}
-
-.highlight .nf {
+/* Functions */
+.token.function,
+.token.function-variable {
   color: #657b83;
   font-weight: normal;
 }
 
-.highlight .nn {
-  color: #555;
+/* Class names */
+.token.class-name {
+  color: #445588;
+  font-weight: bold;
 }
 
-.highlight .nt {
-  color: navy;
-}
-
-.highlight .nv {
+/* Parameters */
+.token.parameter {
   color: #258ad1;
 }
 
-.highlight .ow {
-  color: #000000;
-  font-weight: bold;
-}
-
-.highlight .w {
-  color: #bbb;
-}
-
-.highlight .mf {
-  color: #099;
-}
-
-.highlight .mh {
-  color: #099;
-}
-
-.highlight .mi {
-  color: #4cc0cb;
-}
-
-.highlight .mo {
-  color: #099;
-}
-
-.highlight .sb {
-  color: #d14;
-}
-
-.highlight .sc {
-  color: #d14;
-}
-
-.highlight .sd {
-  color: #d14;
-}
-
-.highlight .s2 {
-  color: #d14;
-}
-
-.highlight .se {
-  color: #d14;
-}
-
-.highlight .sh {
-  color: #d14;
-}
-
-.highlight .si {
-  color: #d14;
-}
-
-.highlight .sx {
-  color: #d14;
-}
-
-.highlight .sr {
+/* Regex, important */
+.token.regex,
+.token.important {
   color: #009926;
 }
 
-.highlight .s1 {
-  color: #4cc0cb;
+/* Bold */
+.token.important,
+.token.bold {
+  font-weight: bold;
 }
 
-.highlight .ss {
-  color: #990073;
+/* Italic */
+.token.italic {
+  font-style: italic;
 }
 
-.highlight .bp {
-  color: #999;
+/* Entity */
+.token.entity {
+  cursor: help;
 }
 
-.highlight .vc {
-  color: teal;
+/* Language-specific overrides */
+
+/* Bash/Shell specific */
+.language-bash .token.assign-left,
+.language-bash .token.builtin {
+  color: #657b83;
 }
 
-.highlight .vg {
-  color: teal;
+/* JavaScript specific */
+.language-javascript .token.literal-property {
+  color: #657b83;
 }
 
-.highlight .vi {
-  color: teal;
-}
-
-.highlight .il {
-  color: #099;
-}
-
-.highlight .nx {
-  color: #687b89;
-}
-
-.highlight .x {
-  color: #258bd2;
+/* Error highlighting */
+.token.error {
+  color: #a61717;
+  background-color: #e3d2d2;
 }


### PR DESCRIPTION
## Summary

This PR restores code highlighting functionality as requested in issue #16, implementing server-side syntax highlighting with conditional CSS loading for optimal performance.

## Changes Made

### ✅ Core Requirements Implemented
- **Code blocks with language indicators**: Preserved existing language classes and added proper syntax highlighting
- **Server-side syntax highlighting**: Implemented using `@11ty/eleventy-plugin-syntaxhighlight` for SSG processing
- **CSS styling**: Extracted syntax highlighting styles into a separate CSS file for better organization
- **Conditional CSS loading**: Only loads syntax highlighting CSS on pages that contain code blocks
- **GitHub Gist handling**: All code is already static (no embedded gists found)

### 📁 Files Modified
- **`.eleventy.js`**: Added syntax highlighting plugin and `hasCodeBlocks` filter
- **`src/_includes/head.njk`**: Added conditional CSS loading logic
- **`package.json`**: Added `@11ty/eleventy-plugin-syntaxhighlight` dependency
- **`.prettierignore`**: Excluded syntax highlighting CSS from formatting

### 📁 Files Created
- **`src/css/syntax-highlighting.css`**: Dedicated CSS file for syntax highlighting styles

## Technical Implementation

### Conditional CSS Loading
```njk
{% if content | hasCodeBlocks %}
<link href='/css/syntax-highlighting.css' rel="stylesheet" type='text/css'>
{% endif %}
```

### Code Block Detection
The `hasCodeBlocks` filter detects pages with syntax-highlighted code blocks using regex pattern matching for language classes.

## Performance Benefits

- **Reduced HTTP requests**: CSS only loaded when needed
- **Smaller page sizes**: Pages without code don't include unnecessary CSS
- **Better caching**: Syntax highlighting CSS can be cached separately

## Testing

✅ **Verified functionality:**
- Code blocks render with proper syntax highlighting
- Multiple languages supported (JavaScript, Bash, PHP, etc.)
- CSS conditionally loads only on pages with code blocks
- Pages without code blocks don't load syntax highlighting CSS
- Build process works correctly

## Example Output

Before: Plain code blocks with basic styling
After: Fully highlighted code with language-specific token classes:

```html
<pre class="language-javascript">
  <code class="language-javascript">
    <span class="token function">server</span><span class="token punctuation">.</span><span class="token function">ext</span><span class="token punctuation">(</span>...
  </code>
</pre>
```

Closes #16

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author