### PR TITLE
ci: bump GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -29,7 +29,7 @@ jobs:
         run: npm ci
 
       - name: Download previous deployment cache
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: deployment-cache
           path: .
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload deployment cache
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: deployment-cache
           path: .deployment-cache.json

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -24,10 +24,10 @@ jobs:
         working-directory: infra
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
           cache: "npm"


### PR DESCRIPTION
Bumps GitHub Actions off the deprecated Node.js 20 runtime, which GitHub forces to Node.js 24 starting June 16, 2026 and removes from runners on September 1, 2026.

- infra.yml: actions/checkout v4 to v5, actions/setup-node v4 to v5
- deploy.yml: same checkout and setup-node bumps, plus actions/download-artifact and actions/upload-artifact v4 to v5

All v5 releases run on Node.js 24, clearing the deprecation warning seen on the Fastly infra workflow run. The artifact v5 actions stay interoperable for the upload-then-download cache pattern, and no input changes were needed.