### PR TITLE
feat: add GitHub Pages deploy alongside Backblaze

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,60 @@
+name: Deploy to GitHub Pages
+
+# Publishes the site to GitHub Pages in parallel with the Backblaze deploy
+# (deploy.yml) while GitHub Pages is being evaluated. Production traffic still
+# flows through Fastly to Backblaze; this only keeps the Pages origin in sync so
+# it can be verified before any Fastly cutover.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: # Allow manual triggering
+
+# Minimum permissions the official Pages deployment flow requires:
+# contents:read for checkout, pages:write to publish, id-token:write for the
+# OIDC token deploy-pages uses to prove the deployment's origin.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Serialize Pages deployments. cancel-in-progress is false so an in-flight
+# deploy is allowed to finish rather than be left half-applied by a newer run.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -26,6 +26,29 @@ npm run deploy:force
 
 ## Deployment Setup
 
+### GitHub Pages (under evaluation, parallel deploy)
+
+`.github/workflows/pages.yml` publishes the site to GitHub Pages on every push to
+`main`, in parallel with the Backblaze deploy below. Production traffic still
+flows through Fastly to Backblaze; this is a staging step to validate GitHub
+Pages before any Fastly cutover, so the two run side by side for now.
+
+One-time repo setup required to serve the custom domain from Pages:
+
+1. Settings -> Pages -> Source: "GitHub Actions"
+2. Settings -> Pages -> Custom domain: `www.tollmanz.com`
+
+Verify the Pages origin without affecting production (Fastly still serves
+Backblaze), using the Host header Fastly will eventually send:
+
+```bash
+# homepage and a pretty-URL post should both return 200
+curl -sSI -H 'Host: www.tollmanz.com' https://tollmanz.github.io/
+curl -sSI -H 'Host: www.tollmanz.com' https://tollmanz.github.io/wp-kses-performance/
+# without the override, GitHub should 301 github.io -> the custom domain
+curl -sSI https://tollmanz.github.io/
+```
+
 ### GitHub Actions CI/CD Setup
 
 For automated deployment on commits to the `main` branch:


### PR DESCRIPTION
PR 1 of 2 in the Backblaze to GitHub Pages migration. This one is purely
additive: GitHub Pages publishing runs in parallel with the existing Backblaze
deploy so the Pages origin can be validated before any Fastly cutover.
Production is unaffected (Fastly still serves Backblaze).

## What changed

- Add `.github/workflows/pages.yml`: builds with Eleventy and publishes via
  `upload-pages-artifact@v5` + `deploy-pages@v5` (OIDC, `github-pages`
  environment) on push to `main` and `workflow_dispatch`
- `.github/workflows/deploy.yml` (Backblaze) and all B2 machinery are left
  untouched
- README documents the one-time Pages settings and verification

## Why split this out

Merging the full migration flips the GitHub Pages publish and the Fastly origin
at the same moment. Splitting lets us prove the Pages origin serves correct
content first, with zero production risk, then do the Fastly cutover in PR 2.

## Verify after merge (or via workflow_dispatch on this branch)

One-time repo setup:

1. Settings to Pages: Source = "GitHub Actions"
2. Settings to Pages: Custom domain = `www.tollmanz.com`

Then probe the Pages origin with the Host header Fastly will eventually send
(production still serves Backblaze, so this is non-disruptive):

```bash
curl -sSI -H 'Host: www.tollmanz.com' https://tollmanz.github.io/
curl -sSI -H 'Host: www.tollmanz.com' https://tollmanz.github.io/wp-kses-performance/
curl -sSI https://tollmanz.github.io/   # expect 301 to https://www.tollmanz.com/
```

Expect 200s for the first two and a 301 to the custom domain for the third. PR 2
(the Fastly cutover plus B2 removal) lands after this is confirmed working.
