### PR TITLE
Add dark mode with a system-default, responsive theme control

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -10,14 +10,23 @@
     </div>
     {% include "footer.njk" %}
     <script>
-      // Theme picker. Not render-blocking: the stored theme is already applied
-      // by the inline script in <head>. This syncs the radio to that choice and
-      // persists changes. "system" needs no matchMedia listener here: data-theme
+      // Theme control. Not render-blocking: the stored theme is already applied
+      // by the inline script in <head>. This syncs the radio to that choice,
+      // persists changes, and runs the narrow-screen dropdown (open/close,
+      // outside-click, Escape). "system" needs no matchMedia listener: data-theme
       // stays "system", so color-scheme: light dark re-resolves with the OS live.
       (function () {
         var root = document.documentElement;
-        var radios = document.querySelectorAll('.theme-picker input[name="theme"]');
-        if (!radios.length) return;
+        var control = document.querySelector(".theme-control");
+        if (!control) return;
+        var toggle = control.querySelector(".theme-control__toggle");
+        var radios = control.querySelectorAll('input[name="theme"]');
+
+        function close() {
+          control.classList.remove("is-open");
+          if (toggle) toggle.setAttribute("aria-expanded", "false");
+        }
+
         var current = root.dataset.theme || "system";
         radios.forEach(function (radio) {
           radio.checked = radio.value === current;
@@ -29,8 +38,22 @@
             } catch (e) {
               /* storage blocked; choice applies for this page only */
             }
+            close();
           });
         });
+
+        if (toggle) {
+          toggle.addEventListener("click", function () {
+            var open = control.classList.toggle("is-open");
+            toggle.setAttribute("aria-expanded", open ? "true" : "false");
+          });
+          document.addEventListener("click", function (event) {
+            if (!control.contains(event.target)) close();
+          });
+          document.addEventListener("keydown", function (event) {
+            if (event.key === "Escape") close();
+          });
+        }
       })();
     </script>
   </body>

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -10,23 +10,26 @@
     </div>
     {% include "footer.njk" %}
     <script>
-      // Theme switch. Not render-blocking: the stored theme is already applied
-      // by the inline script in <head>. Clicking cycles system -> light -> dark
-      // and persists the choice. data-theme drives both color-scheme and icon.
+      // Theme picker. Not render-blocking: the stored theme is already applied
+      // by the inline script in <head>. This syncs the radio to that choice and
+      // persists changes. "system" needs no matchMedia listener here: data-theme
+      // stays "system", so color-scheme: light dark re-resolves with the OS live.
       (function () {
-        var order = ["system", "light", "dark"];
         var root = document.documentElement;
-        var toggle = document.querySelector("[data-theme-toggle]");
-        if (!toggle) return;
-        toggle.addEventListener("click", function () {
-          var next =
-            order[(order.indexOf(root.dataset.theme) + 1) % order.length];
-          root.dataset.theme = next;
-          try {
-            localStorage.setItem("theme", next);
-          } catch (e) {
-            /* storage blocked; choice applies for this page only */
-          }
+        var radios = document.querySelectorAll('.theme-picker input[name="theme"]');
+        if (!radios.length) return;
+        var current = root.dataset.theme || "system";
+        radios.forEach(function (radio) {
+          radio.checked = radio.value === current;
+          radio.addEventListener("change", function () {
+            if (!radio.checked) return;
+            root.dataset.theme = radio.value;
+            try {
+              localStorage.setItem("theme", radio.value);
+            } catch (e) {
+              /* storage blocked; choice applies for this page only */
+            }
+          });
         });
       })();
     </script>

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -9,5 +9,26 @@
       </div>
     </div>
     {% include "footer.njk" %}
+    <script>
+      // Theme switch. Not render-blocking: the stored theme is already applied
+      // by the inline script in <head>. Clicking cycles system -> light -> dark
+      // and persists the choice. data-theme drives both color-scheme and icon.
+      (function () {
+        var order = ["system", "light", "dark"];
+        var root = document.documentElement;
+        var toggle = document.querySelector("[data-theme-toggle]");
+        if (!toggle) return;
+        toggle.addEventListener("click", function () {
+          var next =
+            order[(order.indexOf(root.dataset.theme) + 1) % order.length];
+          root.dataset.theme = next;
+          try {
+            localStorage.setItem("theme", next);
+          } catch (e) {
+            /* storage blocked; choice applies for this page only */
+          }
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -2,6 +2,22 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
+  <script>
+    // Set the saved theme before first paint so the page never flashes. This is
+    // the only render-blocking script; it just maps the stored preference to a
+    // color-scheme via data-theme. The switch behavior loads at end of <body>.
+    (function () {
+      var pref;
+      try {
+        pref = localStorage.getItem("theme");
+      } catch (e) {
+        /* storage blocked; fall through to system */
+      }
+      document.documentElement.dataset.theme =
+        pref === "light" || pref === "dark" ? pref : "system";
+    })();
+  </script>
+
   {% set pageTitle = title or site.title %}
   {% set fullTitle = pageTitle if page.url == "/" else pageTitle + " | " + site.title %}
   {% set pageDescription = description or site.description %}

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -4,27 +4,33 @@
       <span class="logo"></span>
       {{ site.title }}
     </a>
-    <button class="theme-toggle" type="button" data-theme-toggle>
-      <span class="theme-toggle__state" data-state="system">
-        <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false">
-          <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2"></circle>
-          <path d="M12 3a9 9 0 0 1 0 18z" fill="currentColor"></path>
-        </svg>
-        <span class="visually-hidden">Theme: match system. Activate to use light.</span>
-      </span>
-      <span class="theme-toggle__state" data-state="light">
-        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-          <circle cx="12" cy="12" r="4"></circle>
-          <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"></path>
-        </svg>
-        <span class="visually-hidden">Theme: light. Activate to use dark.</span>
-      </span>
-      <span class="theme-toggle__state" data-state="dark">
-        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-        </svg>
-        <span class="visually-hidden">Theme: dark. Activate to match system.</span>
-      </span>
-    </button>
+    <fieldset class="theme-picker">
+      <legend class="visually-hidden">Color theme</legend>
+      <div class="theme-picker__options">
+        <input class="visually-hidden" type="radio" name="theme" id="theme-light" value="light" />
+        <label for="theme-light">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <circle cx="12" cy="12" r="4"></circle>
+            <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"></path>
+          </svg>
+          Light
+        </label>
+        <input class="visually-hidden" type="radio" name="theme" id="theme-system" value="system" />
+        <label for="theme-system">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <rect x="2" y="3" width="20" height="14" rx="2"></rect>
+            <path d="M8 21h8M12 17v4"></path>
+          </svg>
+          System
+        </label>
+        <input class="visually-hidden" type="radio" name="theme" id="theme-dark" value="dark" />
+        <label for="theme-dark">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+          </svg>
+          Dark
+        </label>
+      </div>
+    </fieldset>
   </div>
 </header>

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -4,33 +4,31 @@
       <span class="logo"></span>
       {{ site.title }}
     </a>
-    <fieldset class="theme-picker">
-      <legend class="visually-hidden">Color theme</legend>
-      <div class="theme-picker__options">
-        <input class="visually-hidden" type="radio" name="theme" id="theme-light" value="light" />
-        <label for="theme-light">
-          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-            <circle cx="12" cy="12" r="4"></circle>
-            <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"></path>
-          </svg>
-          Light
-        </label>
-        <input class="visually-hidden" type="radio" name="theme" id="theme-system" value="system" />
-        <label for="theme-system">
-          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-            <rect x="2" y="3" width="20" height="14" rx="2"></rect>
-            <path d="M8 21h8M12 17v4"></path>
-          </svg>
-          System
-        </label>
-        <input class="visually-hidden" type="radio" name="theme" id="theme-dark" value="dark" />
-        <label for="theme-dark">
-          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-          </svg>
-          Dark
-        </label>
+    <div class="theme-control">
+      <button class="theme-control__toggle" type="button" aria-expanded="false" aria-controls="theme-menu" aria-label="Color theme">
+        <svg class="theme-control__icon" data-icon="system" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <rect x="2" y="3" width="20" height="14" rx="2"></rect>
+          <path d="M8 21h8M12 17v4"></path>
+        </svg>
+        <svg class="theme-control__icon" data-icon="light" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <circle cx="12" cy="12" r="4"></circle>
+          <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"></path>
+        </svg>
+        <svg class="theme-control__icon" data-icon="dark" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        </svg>
+      </button>
+      <div class="theme-picker" id="theme-menu" role="radiogroup" aria-labelledby="theme-picker-label">
+        <span class="theme-picker__label" id="theme-picker-label">Theme</span>
+        <div class="theme-picker__options">
+          <input class="visually-hidden" type="radio" name="theme" id="theme-light" value="light" />
+          <label for="theme-light">Light</label>
+          <input class="visually-hidden" type="radio" name="theme" id="theme-system" value="system" />
+          <label for="theme-system">System</label>
+          <input class="visually-hidden" type="radio" name="theme" id="theme-dark" value="dark" />
+          <label for="theme-dark">Dark</label>
+        </div>
       </div>
-    </fieldset>
+    </div>
   </div>
 </header>

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -1,8 +1,30 @@
 <header class="site-header">
   <div class="wrapper">
-      <a class="site-title" href="/">
-          <span class="logo"></span>
-          {{ site.title }}
-      </a>
+    <a class="site-title" href="/">
+      <span class="logo"></span>
+      {{ site.title }}
+    </a>
+    <button class="theme-toggle" type="button" data-theme-toggle>
+      <span class="theme-toggle__state" data-state="system">
+        <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false">
+          <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2"></circle>
+          <path d="M12 3a9 9 0 0 1 0 18z" fill="currentColor"></path>
+        </svg>
+        <span class="visually-hidden">Theme: match system. Activate to use light.</span>
+      </span>
+      <span class="theme-toggle__state" data-state="light">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <circle cx="12" cy="12" r="4"></circle>
+          <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"></path>
+        </svg>
+        <span class="visually-hidden">Theme: light. Activate to use dark.</span>
+      </span>
+      <span class="theme-toggle__state" data-state="dark">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        </svg>
+        <span class="visually-hidden">Theme: dark. Activate to match system.</span>
+      </span>
+    </button>
   </div>
 </header>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -82,6 +82,58 @@
       format("woff");
 }
 
+/* Theme tokens
+
+   Each token carries its light and dark value in one light-dark() call. The
+   browser resolves which to use from the inherited color-scheme, so there is
+   no duplicated dark block and no prefers-color-scheme media query here. */
+:root {
+  /* "light dark" follows the OS. The switch narrows this to a single scheme
+     through the data-theme attribute set by the inline script in head.njk. */
+  color-scheme: light dark;
+
+  --color-bg: light-dark(#f8f8f8, #1a1a1a);
+  --color-text: light-dark(#414141, #e6e6e6);
+  --color-text-muted: light-dark(#828282, #9a9a9a);
+  --color-link: light-dark(#e4322e, #ff6b67);
+  --color-link-hover: light-dark(#af1a17, #ff8f8c);
+  --color-border: light-dark(#e8e8e8, #333333);
+  --color-border-code: light-dark(#dddddd, #383838);
+  --color-rule-top: light-dark(#424242, #555555);
+  --color-logo: light-dark(#313131, #d6d6d6);
+  --color-icon: light-dark(#828282, #9a9a9a);
+  --color-accent: light-dark(#dc322f, #ff6b67);
+  --color-code-bg: light-dark(#f8f8f8, #242424);
+}
+
+/* The switch forces one scheme; "system" (or no attribute) keeps "light dark". */
+:root[data-theme="light"] {
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+}
+
+/* Fallback for browsers without light-dark() (pre-2024): serve the light
+   palette so links keep their color and the brand holds. No dark mode there. */
+@supports not (color: light-dark(#000, #fff)) {
+  :root {
+    --color-bg: #f8f8f8;
+    --color-text: #414141;
+    --color-text-muted: #828282;
+    --color-link: #e4322e;
+    --color-link-hover: #af1a17;
+    --color-border: #e8e8e8;
+    --color-border-code: #dddddd;
+    --color-rule-top: #424242;
+    --color-logo: #313131;
+    --color-icon: #828282;
+    --color-accent: #dc322f;
+    --color-code-bg: #f8f8f8;
+  }
+}
+
 /* Reset */
 body,
 h1,
@@ -110,8 +162,11 @@ body {
   font-size: 18px;
   line-height: 2;
   font-weight: 300;
-  color: #414141;
-  background-color: #f8f8f8;
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease;
 }
 
 h1,
@@ -174,17 +229,18 @@ li p {
 }
 
 a {
-  color: #e4322e;
+  color: var(--color-link);
   text-decoration: none;
+  transition: color 0.15s ease;
 }
 
 a:hover {
-  color: #af1a17;
+  color: var(--color-link-hover);
 }
 
 blockquote {
-  color: #828282;
-  border-left: 4px solid #e8e8e8;
+  color: var(--color-text-muted);
+  border-left: 4px solid var(--color-border);
   padding-left: 15px;
   font-size: 18px;
   letter-spacing: -1px;
@@ -209,8 +265,8 @@ code {
 pre {
   padding: 8px 0;
   overflow-x: scroll;
-  border-top: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
+  border-top: 1px solid var(--color-border-code);
+  border-bottom: 1px solid var(--color-border-code);
 }
 
 pre > code {
@@ -250,15 +306,27 @@ pre > code {
 }
 
 .icon > svg path {
-  fill: #828282;
+  fill: var(--color-icon);
 }
 
 /* Site header */
 .site-header {
-  border-top: 5px solid #424242;
-  border-bottom: 1px solid #e8e8e8;
+  border-top: 5px solid var(--color-rule-top);
+  border-bottom: 1px solid var(--color-border);
   min-height: 56px;
   padding: 30px 0;
+}
+
+.site-header .wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+/* The shared .wrapper clearfix adds a stray flex item; drop it in the header. */
+.site-header .wrapper::after {
+  display: none;
 }
 
 .site-title {
@@ -271,7 +339,7 @@ pre > code {
   height: 16px;
   width: 16px;
   border-radius: 50%;
-  border: 8px solid #313131;
+  border: 8px solid var(--color-logo);
   display: inline-block;
   vertical-align: middle;
   line-height: 56px;
@@ -293,7 +361,7 @@ pre > code {
 
 /* Site footer */
 .site-footer {
-  border-top: 1px solid #e8e8e8;
+  border-top: 1px solid var(--color-border);
   padding: 30px 0;
   font-size: 15px;
 }
@@ -319,14 +387,14 @@ pre > code {
 
 .post-meta {
   font-size: 15.75px;
-  color: #828282;
+  color: var(--color-text-muted);
 }
 
 .post-link {
   display: block;
   font-size: 24px;
   line-height: 1.4;
-  color: #414141;
+  color: var(--color-text);
 }
 
 .post-header {
@@ -385,7 +453,7 @@ pre > code {
 
 .footnote-article-number,
 .footnote-footer-number {
-  color: #dc322f;
+  color: var(--color-accent);
   vertical-align: super;
   font-weight: 600;
   font-size: 14px;
@@ -706,4 +774,78 @@ pre > code {
 
 .highlight .x {
   color: #258bd2;
+}
+
+/* Theme toggle */
+.theme-toggle {
+  /* Hidden until the inline script sets data-theme on <html>, so it never
+     shows when JavaScript is unavailable and could not function. */
+  display: none;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: none;
+  color: var(--color-icon);
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease;
+}
+
+:root[data-theme] .theme-toggle {
+  display: inline-flex;
+}
+
+.theme-toggle:hover {
+  color: var(--color-link);
+  background-color: var(--color-border);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--color-link);
+  outline-offset: 2px;
+}
+
+.theme-toggle svg {
+  display: block;
+  width: 20px;
+  height: 20px;
+  transition: transform 0.2s ease;
+}
+
+.theme-toggle:hover svg {
+  transform: rotate(15deg) scale(1.08);
+}
+
+/* Only the state matching the current theme is rendered; its label provides
+   the button's accessible name and updates as the theme changes. */
+.theme-toggle__state {
+  display: none;
+  align-items: center;
+}
+
+:root[data-theme="system"] .theme-toggle__state[data-state="system"],
+:root[data-theme="light"] .theme-toggle__state[data-state="light"],
+:root[data-theme="dark"] .theme-toggle__state[data-state="dark"] {
+  display: inline-flex;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+  }
+
+  .theme-toggle:hover svg {
+    transform: none;
+  }
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -108,9 +108,8 @@
   --color-accent: light-dark(#dc322f, #eed3b1);
   --color-code-bg: light-dark(#f8f8f8, #241f1a);
 
-  /* Segmented control surfaces: a sunken track and a raised selected segment. */
+  /* Surface for the floating theme panel and its button. */
   --color-surface: light-dark(#ffffff, #2e2823);
-  --color-surface-sunken: light-dark(#ececec, #13100d);
 }
 
 /* The switch forces one scheme; "system" (or no attribute) keeps "light dark". */
@@ -139,7 +138,6 @@
     --color-accent: #dc322f;
     --color-code-bg: #f8f8f8;
     --color-surface: #ffffff;
-    --color-surface-sunken: #ececec;
   }
 }
 
@@ -786,83 +784,119 @@ pre > code {
   color: #258bd2;
 }
 
-/* Theme picker
+/* Theme control
 
-   A labeled, three-state segmented control built on native radios, so it
-   announces correctly and arrow keys move between options. Hidden until the
-   inline script sets data-theme on <html>, since it cannot work without JS. */
-.theme-picker {
+   Wide screens: a floating panel pinned to the far right, in the gutter beside
+   the left-aligned content column, so it never overlaps the page. Narrow
+   screens: a small header button that opens the options as a dropdown menu.
+   Built on native radios; the active option is shown by the accent color and
+   bold weight (not color alone). Hidden until the inline script sets data-theme
+   on <html>, since it needs JS to function. */
+.theme-control {
+  position: relative;
   display: none;
   flex: none;
-  min-width: 0; /* opt out of the fieldset min-width that breaks flex layouts */
-  margin: 0;
-  padding: 0;
-  border: 0;
 }
 
-:root[data-theme] .theme-picker {
+:root[data-theme] .theme-control {
   display: block;
 }
 
-/* The site does not set border-box globally, so scope it here to keep the
-   width: 100% track from overflowing once padding and border are added. */
-.theme-picker,
-.theme-picker * {
-  box-sizing: border-box;
+/* Button that opens the menu on narrow screens (hidden on wide screens). */
+.theme-control__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-surface);
+  color: var(--color-icon);
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+  transition:
+    color 0.18s ease,
+    border-color 0.2s ease;
 }
 
-.theme-picker__options {
-  display: inline-flex;
-  gap: 4px;
-  padding: 4px;
-  background: var(--color-surface-sunken);
+.theme-control__toggle:hover {
+  color: var(--color-link);
+}
+
+.theme-control__toggle:focus-visible {
+  outline: 2px solid var(--color-link);
+  outline-offset: 2px;
+}
+
+/* Show only the icon for the active theme. */
+.theme-control__icon {
+  display: none;
+}
+
+:root[data-theme="system"] .theme-control__icon[data-icon="system"],
+:root[data-theme="light"] .theme-control__icon[data-icon="light"],
+:root[data-theme="dark"] .theme-control__icon[data-icon="dark"] {
+  display: block;
+}
+
+/* The panel/menu, shared by both presentations. */
+.theme-picker {
+  min-width: 0;
+  margin: 0;
+  padding: 8px 12px;
   border: 1px solid var(--color-border);
-  border-radius: 12px;
+  border-radius: 10px;
+  background: var(--color-surface);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.14);
   transition:
     background-color 0.2s ease,
     border-color 0.2s ease;
 }
 
+.theme-picker__label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.theme-picker__options {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
 .theme-picker label {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  padding: 8px 14px;
-  border-radius: 9px;
+  display: block;
+  padding: 8px 12px;
+  border-radius: 6px;
   cursor: pointer;
   font-size: 14px;
-  line-height: 1;
+  line-height: 1.4;
   color: var(--color-text);
   white-space: nowrap;
   -webkit-user-select: none;
   user-select: none;
-  transition:
-    background-color 0.18s ease,
-    color 0.18s ease;
-}
-
-.theme-picker label svg {
-  flex: none;
-  width: 16px;
-  height: 16px;
+  transition: color 0.15s ease;
 }
 
 .theme-picker label:hover {
   color: var(--color-link);
 }
 
-/* Active option: a raised surface plus shadow, not color alone, so the choice
-   stays clear in high-contrast and color-blind contexts. Driven by the real
-   :checked state and, before the script syncs the radios, by data-theme, so the
-   selection is correct from the first paint. */
+/* Active option: accent color plus bold weight, not color alone. Driven by the
+   real :checked state and, before the script syncs the radios, by data-theme. */
 .theme-picker input:checked + label,
 :root[data-theme="light"] .theme-picker label[for="theme-light"],
 :root[data-theme="dark"] .theme-picker label[for="theme-dark"],
 :root[data-theme="system"] .theme-picker label[for="theme-system"] {
-  background: var(--color-surface);
-  color: var(--color-text);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+  color: var(--color-link);
+  font-weight: 700;
 }
 
 .theme-picker input:focus-visible + label {
@@ -870,22 +904,53 @@ pre > code {
   outline-offset: 2px;
 }
 
-/* Small screens: the control drops below the title and fills the row as three
-   equal segments. */
-@media screen and (max-width: 600px) {
+/* Narrow screens: the menu drops down under the header button. */
+@media (max-width: 1119px) {
   .theme-picker {
-    width: 100%;
+    display: none;
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    z-index: 50;
+    min-width: 150px;
+  }
+
+  .theme-control.is-open .theme-picker {
+    display: block;
+  }
+}
+
+/* Wide screens: float the panel at the far right, outside the content column;
+   no button, panel always visible, label and options in one row. */
+@media (min-width: 1120px) {
+  .theme-control {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    z-index: 50;
+  }
+
+  .theme-control__toggle {
+    display: none;
+  }
+
+  .theme-picker {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .theme-picker__label {
+    margin-bottom: 0;
   }
 
   .theme-picker__options {
-    display: flex;
-    width: 100%;
+    flex-direction: row;
+    gap: 4px;
   }
 
   .theme-picker label {
-    flex: 1;
-    padding-right: 8px;
-    padding-left: 8px;
+    padding: 6px 10px;
   }
 }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -107,6 +107,10 @@
   --color-icon: light-dark(#828282, #a89f93);
   --color-accent: light-dark(#dc322f, #eed3b1);
   --color-code-bg: light-dark(#f8f8f8, #241f1a);
+
+  /* Segmented control surfaces: a sunken track and a raised selected segment. */
+  --color-surface: light-dark(#ffffff, #2e2823);
+  --color-surface-sunken: light-dark(#ececec, #13100d);
 }
 
 /* The switch forces one scheme; "system" (or no attribute) keeps "light dark". */
@@ -134,6 +138,8 @@
     --color-icon: #828282;
     --color-accent: #dc322f;
     --color-code-bg: #f8f8f8;
+    --color-surface: #ffffff;
+    --color-surface-sunken: #ececec;
   }
 }
 
@@ -322,6 +328,7 @@ pre > code {
 
 .site-header .wrapper {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
@@ -779,66 +786,107 @@ pre > code {
   color: #258bd2;
 }
 
-/* Theme toggle */
-.theme-toggle {
-  /* Hidden until the inline script sets data-theme on <html>, so it never
-     shows when JavaScript is unavailable and could not function. */
+/* Theme picker
+
+   A labeled, three-state segmented control built on native radios, so it
+   announces correctly and arrow keys move between options. Hidden until the
+   inline script sets data-theme on <html>, since it cannot work without JS. */
+.theme-picker {
   display: none;
   flex: none;
-  align-items: center;
-  justify-content: center;
-  width: 44px;
-  height: 44px;
+  min-width: 0; /* opt out of the fieldset min-width that breaks flex layouts */
   margin: 0;
   padding: 0;
   border: 0;
-  border-radius: 50%;
-  background: none;
-  color: var(--color-icon);
-  cursor: pointer;
-  -webkit-appearance: none;
-  appearance: none;
-  transition:
-    color 0.2s ease,
-    background-color 0.2s ease;
 }
 
-:root[data-theme] .theme-toggle {
+:root[data-theme] .theme-picker {
+  display: block;
+}
+
+/* The site does not set border-box globally, so scope it here to keep the
+   width: 100% track from overflowing once padding and border are added. */
+.theme-picker,
+.theme-picker * {
+  box-sizing: border-box;
+}
+
+.theme-picker__options {
   display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--color-surface-sunken);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
 }
 
-.theme-toggle:hover {
+.theme-picker label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 8px 14px;
+  border-radius: 9px;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--color-text);
+  white-space: nowrap;
+  -webkit-user-select: none;
+  user-select: none;
+  transition:
+    background-color 0.18s ease,
+    color 0.18s ease;
+}
+
+.theme-picker label svg {
+  flex: none;
+  width: 16px;
+  height: 16px;
+}
+
+.theme-picker label:hover {
   color: var(--color-link);
-  background-color: var(--color-border);
 }
 
-.theme-toggle:focus-visible {
+/* Active option: a raised surface plus shadow, not color alone, so the choice
+   stays clear in high-contrast and color-blind contexts. Driven by the real
+   :checked state and, before the script syncs the radios, by data-theme, so the
+   selection is correct from the first paint. */
+.theme-picker input:checked + label,
+:root[data-theme="light"] .theme-picker label[for="theme-light"],
+:root[data-theme="dark"] .theme-picker label[for="theme-dark"],
+:root[data-theme="system"] .theme-picker label[for="theme-system"] {
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.theme-picker input:focus-visible + label {
   outline: 2px solid var(--color-link);
   outline-offset: 2px;
 }
 
-.theme-toggle svg {
-  display: block;
-  width: 20px;
-  height: 20px;
-  transition: transform 0.2s ease;
-}
+/* Small screens: the control drops below the title and fills the row as three
+   equal segments. */
+@media screen and (max-width: 600px) {
+  .theme-picker {
+    width: 100%;
+  }
 
-.theme-toggle:hover svg {
-  transform: rotate(15deg) scale(1.08);
-}
+  .theme-picker__options {
+    display: flex;
+    width: 100%;
+  }
 
-/* Only the state matching the current theme is rendered; its label provides
-   the button's accessible name and updates as the theme changes. */
-.theme-toggle__state {
-  display: none;
-  align-items: center;
-}
-
-:root[data-theme="system"] .theme-toggle__state[data-state="system"],
-:root[data-theme="light"] .theme-toggle__state[data-state="light"],
-:root[data-theme="dark"] .theme-toggle__state[data-state="dark"] {
-  display: inline-flex;
+  .theme-picker label {
+    flex: 1;
+    padding-right: 8px;
+    padding-left: 8px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -846,9 +894,5 @@ pre > code {
   *::before,
   *::after {
     transition-duration: 0.01ms !important;
-  }
-
-  .theme-toggle:hover svg {
-    transform: none;
   }
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -110,6 +110,10 @@
 
   /* Surface for the floating theme panel and its button. */
   --color-surface: light-dark(#ffffff, #2e2823);
+
+  /* Accent for the active picker option. Darker than --color-link in light so
+     it clears WCAG AA (4.5:1) on the white panel surface; dark keeps the tan. */
+  --color-accent-strong: light-dark(#cf2b27, #eed3b1);
 }
 
 /* The switch forces one scheme; "system" (or no attribute) keeps "light dark". */
@@ -138,6 +142,7 @@
     --color-accent: #dc322f;
     --color-code-bg: #f8f8f8;
     --color-surface: #ffffff;
+    --color-accent-strong: #cf2b27;
   }
 }
 
@@ -886,7 +891,7 @@ pre > code {
 }
 
 .theme-picker label:hover {
-  color: var(--color-link);
+  color: var(--color-accent-strong);
 }
 
 /* Active option: accent color plus bold weight, not color alone. Driven by the
@@ -895,7 +900,7 @@ pre > code {
 :root[data-theme="light"] .theme-picker label[for="theme-light"],
 :root[data-theme="dark"] .theme-picker label[for="theme-dark"],
 :root[data-theme="system"] .theme-picker label[for="theme-system"] {
-  color: var(--color-link);
+  color: var(--color-accent-strong);
   font-weight: 700;
 }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -89,21 +89,24 @@
    no duplicated dark block and no prefers-color-scheme media query here. */
 :root {
   /* "light dark" follows the OS. The switch narrows this to a single scheme
-     through the data-theme attribute set by the inline script in head.njk. */
+     through the data-theme attribute set by the inline script in head.njk.
+     Dark palette: warm charcoal base with a tan callout.
+     #1a1613 bg, #f4f1ea warm-white text, #eed3b1 tan link/accent,
+     #241f1a raised surfaces, #a89f93 warm-gray muted text. */
   color-scheme: light dark;
 
-  --color-bg: light-dark(#f8f8f8, #1a1a1a);
-  --color-text: light-dark(#414141, #e6e6e6);
-  --color-text-muted: light-dark(#828282, #9a9a9a);
-  --color-link: light-dark(#e4322e, #ff6b67);
-  --color-link-hover: light-dark(#af1a17, #ff8f8c);
-  --color-border: light-dark(#e8e8e8, #333333);
-  --color-border-code: light-dark(#dddddd, #383838);
-  --color-rule-top: light-dark(#424242, #555555);
-  --color-logo: light-dark(#313131, #d6d6d6);
-  --color-icon: light-dark(#828282, #9a9a9a);
-  --color-accent: light-dark(#dc322f, #ff6b67);
-  --color-code-bg: light-dark(#f8f8f8, #242424);
+  --color-bg: light-dark(#f8f8f8, #1a1613);
+  --color-text: light-dark(#414141, #f4f1ea);
+  --color-text-muted: light-dark(#828282, #a89f93);
+  --color-link: light-dark(#e4322e, #eed3b1);
+  --color-link-hover: light-dark(#af1a17, #f6e6cf);
+  --color-border: light-dark(#e8e8e8, #332e27);
+  --color-border-code: light-dark(#dddddd, #332e27);
+  --color-rule-top: light-dark(#424242, #4a443b);
+  --color-logo: light-dark(#313131, #f4f1ea);
+  --color-icon: light-dark(#828282, #a89f93);
+  --color-accent: light-dark(#dc322f, #eed3b1);
+  --color-code-bg: light-dark(#f8f8f8, #241f1a);
 }
 
 /* The switch forces one scheme; "system" (or no attribute) keeps "light dark". */

--- a/src/css/syntax-highlighting.css
+++ b/src/css/syntax-highlighting.css
@@ -1,15 +1,51 @@
 /* Syntax highlighting styles for token-based markup */
 
+/* Token palette. Each token pairs its light and dark value in one light-dark()
+   call, resolved from the color-scheme set on :root in main.css. The code-block
+   frame (background, text, border) reuses the shared --color-* tokens. */
+:root {
+  --tok-comment: light-dark(#999988, #8b919b);
+  --tok-punctuation: light-dark(#999999, #abb2bf);
+  --tok-property: light-dark(#4cc0cb, #56b6c2);
+  --tok-string: light-dark(#dd1144, #98c379);
+  --tok-operator: light-dark(#849a22, #d19a66);
+  --tok-keyword: light-dark(#a79d00, #c678dd);
+  --tok-function: light-dark(#657b83, #61afef);
+  --tok-class: light-dark(#445588, #e5c07b);
+  --tok-parameter: light-dark(#258ad1, #d19a66);
+  --tok-regex: light-dark(#009926, #56b6c2);
+  --tok-error-fg: light-dark(#a61717, #ff8a87);
+  --tok-error-bg: light-dark(#e3d2d2, #4a2a2a);
+}
+
+/* Fallback for browsers without light-dark(): the light token palette. */
+@supports not (color: light-dark(#000, #fff)) {
+  :root {
+    --tok-comment: #999988;
+    --tok-punctuation: #999999;
+    --tok-property: #4cc0cb;
+    --tok-string: #dd1144;
+    --tok-operator: #849a22;
+    --tok-keyword: #a79d00;
+    --tok-function: #657b83;
+    --tok-class: #445588;
+    --tok-parameter: #258ad1;
+    --tok-regex: #009926;
+    --tok-error-fg: #a61717;
+    --tok-error-bg: #e3d2d2;
+  }
+}
+
 /* Base code block styling */
 pre[class*="language-"] {
-  background: #f8f8f8;
-  color: #414141;
+  background: var(--color-code-bg);
+  color: var(--color-text);
   line-height: 1;
   margin-bottom: 30px;
   padding: 8px 12px;
   overflow-x: auto;
-  border-top: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
+  border-top: 1px solid var(--color-border-code);
+  border-bottom: 1px solid var(--color-border-code);
 }
 
 code[class*="language-"] {
@@ -25,13 +61,13 @@ code[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #999988;
+  color: var(--tok-comment);
   font-style: italic;
 }
 
 /* Punctuation */
 .token.punctuation {
-  color: #999999;
+  color: var(--tok-punctuation);
 }
 
 /* Properties, tags, boolean, number, constant, symbol, deleted */
@@ -42,7 +78,7 @@ code[class*="language-"] {
 .token.constant,
 .token.symbol,
 .token.deleted {
-  color: #4cc0cb;
+  color: var(--tok-property);
 }
 
 /* Selectors, attributes, strings, chars, built-ins, inserted */
@@ -52,7 +88,7 @@ code[class*="language-"] {
 .token.char,
 .token.builtin,
 .token.inserted {
-  color: #d14;
+  color: var(--tok-string);
 }
 
 /* Operators, entities, url, language-css .string, style .string, variables */
@@ -62,7 +98,7 @@ code[class*="language-"] {
 .language-css .token.string,
 .style .token.string,
 .token.variable {
-  color: #849a22;
+  color: var(--tok-operator);
   font-weight: bold;
 }
 
@@ -71,32 +107,32 @@ code[class*="language-"] {
 .token.atrule,
 .token.attr-value,
 .token.important {
-  color: #a79d00;
+  color: var(--tok-keyword);
   font-weight: normal;
 }
 
 /* Functions */
 .token.function,
 .token.function-variable {
-  color: #657b83;
+  color: var(--tok-function);
   font-weight: normal;
 }
 
 /* Class names */
 .token.class-name {
-  color: #445588;
+  color: var(--tok-class);
   font-weight: bold;
 }
 
 /* Parameters */
 .token.parameter {
-  color: #258ad1;
+  color: var(--tok-parameter);
 }
 
 /* Regex, important */
 .token.regex,
 .token.important {
-  color: #009926;
+  color: var(--tok-regex);
 }
 
 /* Bold */
@@ -120,16 +156,16 @@ code[class*="language-"] {
 /* Bash/Shell specific */
 .language-bash .token.assign-left,
 .language-bash .token.builtin {
-  color: #657b83;
+  color: var(--tok-function);
 }
 
 /* JavaScript specific */
 .language-javascript .token.literal-property {
-  color: #657b83;
+  color: var(--tok-function);
 }
 
 /* Error highlighting */
 .token.error {
-  color: #a61717;
-  background-color: #e3d2d2;
+  color: var(--tok-error-fg);
+  background-color: var(--tok-error-bg);
 }

--- a/src/css/syntax-highlighting.css
+++ b/src/css/syntax-highlighting.css
@@ -2,20 +2,22 @@
 
 /* Token palette. Each token pairs its light and dark value in one light-dark()
    call, resolved from the color-scheme set on :root in main.css. The code-block
-   frame (background, text, border) reuses the shared --color-* tokens. */
+   frame (background, text, border) reuses the shared --color-* tokens. The dark
+   accents are a Gruvbox-style warm set, chosen to sit on the warm charcoal code
+   background and stay distinct from one another. */
 :root {
-  --tok-comment: light-dark(#999988, #8b919b);
-  --tok-punctuation: light-dark(#999999, #abb2bf);
-  --tok-property: light-dark(#4cc0cb, #56b6c2);
-  --tok-string: light-dark(#dd1144, #98c379);
-  --tok-operator: light-dark(#849a22, #d19a66);
-  --tok-keyword: light-dark(#a79d00, #c678dd);
-  --tok-function: light-dark(#657b83, #61afef);
-  --tok-class: light-dark(#445588, #e5c07b);
-  --tok-parameter: light-dark(#258ad1, #d19a66);
-  --tok-regex: light-dark(#009926, #56b6c2);
-  --tok-error-fg: light-dark(#a61717, #ff8a87);
-  --tok-error-bg: light-dark(#e3d2d2, #4a2a2a);
+  --tok-comment: light-dark(#999988, #9c8d7c);
+  --tok-punctuation: light-dark(#999999, #a89f93);
+  --tok-property: light-dark(#4cc0cb, #d3869b);
+  --tok-string: light-dark(#dd1144, #b8bb26);
+  --tok-operator: light-dark(#849a22, #fe8019);
+  --tok-keyword: light-dark(#a79d00, #fb4934);
+  --tok-function: light-dark(#657b83, #8ec07c);
+  --tok-class: light-dark(#445588, #fabd2f);
+  --tok-parameter: light-dark(#258ad1, #83a598);
+  --tok-regex: light-dark(#009926, #8ec07c);
+  --tok-error-fg: light-dark(#a61717, #fb4934);
+  --tok-error-bg: light-dark(#e3d2d2, #2a1814);
 }
 
 /* Fallback for browsers without light-dark(): the light token palette. */


### PR DESCRIPTION
Adds a dark theme that defaults to the visitor's OS setting, implemented with CSS `light-dark()` and `color-scheme` plus a tiny inline setter in `<head>` so there is no flash on load. The dark palette is a warm charcoal with a tan accent, and code blocks get a matching Gruvbox-style warm syntax highlighting. A three-state Light / System / Dark control built on native radios floats in the right gutter on wide screens and collapses to a header button that opens a dropdown menu below 1120px. `System` tracks the OS live with no `matchMedia` listener, and the control stays accessible via a labeled radiogroup, keyboard support, focus-visible rings, and a non-color selected state.
