### PR TITLE
Add slide view transition between pages

### DIFF
--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -2,6 +2,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
+  {# Preload the above-the-fold fonts (Coustard headings, Ubuntu 300 body) so
+     they are applied before first paint. A view transition snapshots the new
+     page at first paint; without this the snapshot captures the fallback font
+     and the swap-in becomes a visible FOUT frozen by the transition. The
+     crossorigin attr is required even same-origin or the font downloads twice. #}
+  <link rel="preload" href="/fonts/coustard-42be12704ef50999d53a7c55da2bb7522ef1efde.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/fonts/ubuntu-e4c86e820c9a5f86c6832a68e432c6bf6981084b.woff2" as="font" type="font/woff2" crossorigin>
+
   {% set pageTitle = title or site.title %}
   {% set fullTitle = pageTitle if page.url == "/" else pageTitle + " | " + site.title %}
   {% set pageDescription = description or site.description %}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -707,3 +707,54 @@ pre > code {
 .highlight .x {
   color: #258bd2;
 }
+
+/* View transitions */
+/* Cross-document (MPA) slide-and-fade. One CSS opt-in animates between page
+   loads with zero JavaScript; engines without support navigate normally, so
+   this is pure progressive enhancement. The opt-in must be on every page,
+   which it is, since this stylesheet is loaded sitewide. */
+@view-transition {
+  navigation: auto;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  /* Hold the masthead and footer still across pages so they don't shimmer:
+     the same name in the same position is treated as one continuous element. */
+  .site-header {
+    view-transition-name: site-header;
+  }
+  .site-footer {
+    view-transition-name: site-footer;
+  }
+
+  /* Content lifts out on exit and settles in from a small offset on enter.
+     transform + opacity only, so the animation stays on the GPU compositor. */
+  ::view-transition-old(root) {
+    animation: 220ms ease both vt-slide-out;
+  }
+  ::view-transition-new(root) {
+    animation: 220ms ease both vt-slide-in;
+  }
+
+  @keyframes vt-slide-out {
+    to {
+      opacity: 0;
+      transform: translateY(-16px);
+    }
+  }
+  @keyframes vt-slide-in {
+    from {
+      opacity: 0;
+      transform: translateY(16px);
+    }
+  }
+}
+
+/* Respect reduced motion: keep the instant DOM swap, drop the animation. */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## What

Adds a cross-document slide-and-fade view transition between page loads.

On every navigation the content area slides while the masthead and footer
hold still. Pure CSS via the View Transitions API, zero JavaScript. It is
progressive enhancement: browsers without cross-document support (Safari,
Firefox today) navigate normally with no penalty.

## How

- `src/css/main.css`: `@view-transition { navigation: auto }`, slide
  keyframes on `::view-transition-old/new(root)`, and `.site-header` /
  `.site-footer` named so the chrome stays continuous. Animates only
  `transform` and `opacity`, so it runs on the compositor. Disabled under
  `prefers-reduced-motion: reduce`.
- `src/_includes/head.njk`: preload the above-the-fold Coustard and Ubuntu
  fonts. A transition snapshots the new page at first paint, which does not
  wait for `font-display: swap` fonts; without the preload the snapshot
  captures the fallback and the swap-in flashes. The preloads also reduce
  FOUT and layout shift on ordinary loads.

## Notes

- Cross-document transitions ship in Chromium (Chrome/Edge 126+).
- The Eleventy dev server has no asset caching, so link-click transitions
  intermittently skip locally (back/forward is immune). Production on
  GitHub Pages caches assets and is reliable; preview with
  `npm run build` then `npx http-server public -c3600`.

## Verification

Built output is zero `<script>` on home, post, and about pages. Confirmed
in Chrome 149 that the transition fires on a real link click with the slide
keyframes and the persistent-chrome group animations running. `npm run
build`, ESLint, and Prettier all pass.
