### PR TITLE
ci: purge Fastly cache after Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -56,3 +56,21 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+      # Fastly caches the whole site, so freshly published content stays hidden
+      # behind stale edge copies until their TTL expires. A purge_all after the
+      # deploy clears every object at once; the next request for each URL misses
+      # and re-fetches from GitHub Pages. The site is static and fully
+      # regenerated on each deploy, so purging everything is safe. The token is
+      # scoped to purge_all only (separate from the Pulumi write token), and the
+      # non-secret service ID comes from an Actions variable.
+      - name: Purge Fastly cache
+        env:
+          FASTLY_PURGE_TOKEN: ${{ secrets.FASTLY_PURGE_TOKEN }}
+          FASTLY_SERVICE_ID: ${{ vars.FASTLY_SERVICE_ID }}
+        run: |
+          curl --fail --silent --show-error \
+            --request POST \
+            --header "Fastly-Key: ${FASTLY_PURGE_TOKEN}" \
+            --header "Accept: application/json" \
+            "https://api.fastly.com/service/${FASTLY_SERVICE_ID}/purge_all"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -56,14 +56,6 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
-
-      # Fastly caches the whole site, so freshly published content stays hidden
-      # behind stale edge copies until their TTL expires. A purge_all after the
-      # deploy clears every object at once; the next request for each URL misses
-      # and re-fetches from GitHub Pages. The site is static and fully
-      # regenerated on each deploy, so purging everything is safe. The token is
-      # scoped to purge_all only (separate from the Pulumi write token), and the
-      # non-secret service ID comes from an Actions variable.
       - name: Purge Fastly cache
         env:
           FASTLY_PURGE_TOKEN: ${{ secrets.FASTLY_PURGE_TOKEN }}


### PR DESCRIPTION
## What

Adds a `purge_all` step to the `deploy` job in `pages.yml`, running right after `actions/deploy-pages` succeeds. Fastly fronts GitHub Pages and caches the whole site, so freshly published content otherwise stays hidden behind stale edge copies until TTL expires. The purge clears every object at once; the next request for each URL misses and re-fetches from GitHub Pages.

The site is static and fully regenerated on each deploy, so purging everything is safe.

## Config

Two repo-level settings, kept out of source:

- `FASTLY_PURGE_TOKEN` (secret): a Fastly token scoped to `purge_all` only, separate from the broad Pulumi write token (`FASTLY_API_KEY`). Least privilege, so a leak here can only purge cache.
- `FASTLY_SERVICE_ID` (variable): non-secret service ID. Verified to match the Pulumi `serviceId` output (`CbMtkc2QTDfGfdMMRupTLg`).

Both are already set on the repo.

## Notes

- Runs only after a successful deploy, so a failed deploy won't purge
- `--fail` makes the step go red on a bad token or wrong ID, so misconfiguration surfaces in CI
- `purge_all` is a hard purge (instant); it cannot run in soft-purge mode
- The token's `purge_all` scope is verified end to end on the first run on `main`