### PR TITLE
fix: drop parens from Fastly snippet names

### DIFF
--- a/infra/index.ts
+++ b/infra/index.ts
@@ -127,13 +127,13 @@ const site = new fastly.ServiceVcl(
         content: apexRedirectError,
       },
       {
-        name: "Force identity fetch for edge compression (miss)",
+        name: "Force identity fetch for edge compression - miss",
         type: "miss",
         priority: 100,
         content: forceIdentityFetch,
       },
       {
-        name: "Force identity fetch for edge compression (pass)",
+        name: "Force identity fetch for edge compression - pass",
         type: "pass",
         priority: 100,
         content: forceIdentityFetch,


### PR DESCRIPTION
Follow-up to #49. The `pulumi up` apply on main failed with:

```
400 - Bad Request
Detail: Name must start with a letter and contain only alphanumeric, underscore, hyphen, period, and space
```

The two new snippet names used parentheses (`(miss)`, `(pass)`), which Fastly rejects. Renamed to use a hyphen separator. The apply failed atomically, so the live service is unchanged and brotli is still not enabled until this lands.

The brotli product enablement itself was never reached because the name validation short-circuited the update, so that risk (account entitlement) is still unproven; the next apply will tell us. Verification after merge unchanged from #49: expect `content-encoding: br` for browser/br requests, `gzip` for gzip-only clients.