### PR TITLE
chore: add Conductor workspace scripts

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,12 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+# New workspaces are fresh git worktrees with no node_modules; install on
+# creation so the Eleventy CLI is available without a manual npm ci.
+setup = "npm ci"
+# Serve the dev build on the workspace's assigned port so parallel workspaces
+# don't collide on Eleventy's default 8080.
+run = "npm run dev -- --port $CONDUCTOR_PORT"
+# Static site with no shared port/database, so multiple workspaces can serve
+# at once.
+run_mode = "concurrent"


### PR DESCRIPTION
Adds `.conductor/settings.toml` so every new Conductor workspace is ready to build and serve without manual steps.

## Why
A new workspace is a fresh git worktree with no `node_modules`, so the Eleventy CLI is missing until something runs `npm`. This bit the image-cleanup workspace (`eleventy: command not found` until `npm ci`). With a setup script, Conductor installs deps on workspace creation.

## What
- `scripts.setup = "npm ci"` installs dependencies when a workspace is created
- `scripts.run = "npm run dev -- --port $CONDUCTOR_PORT"` serves the dev build on the workspace's assigned port instead of Eleventy's default 8080, so parallel workspaces don't collide
- `scripts.run_mode = "concurrent"` since this static site shares no fixed port, database, or local stack across workspaces

`.env` is already copied into new workspaces by Conductor's default `.env*` rule, so no Files-to-copy change is needed.

Validated with `taplo lint` against the Conductor repo settings schema. Conductor reads repo settings from the root checkout, so this takes effect for workspaces created after it merges to `main`.