### PR TITLE
test: add post-deploy edge verification suite

### DIFF
--- a/.github/workflows/edge-verify.yml
+++ b/.github/workflows/edge-verify.yml
@@ -1,0 +1,51 @@
+name: Edge verification
+
+# Smoke-tests the live production edge (Fastly in front of GitHub Pages) against
+# the contract in docs/edge-caching.md: Cache-Control by asset class, 304
+# revalidation, brotli/gzip negotiation, redirects, HSTS, HTTP/2 and HTTP/3, and
+# TLS resumption / 0-RTT. The tests need no npm dependencies, just curl and
+# openssl, which the runner already has.
+#
+# It runs after either deploy pipeline finishes on main (the site via
+# "Deploy to GitHub Pages", the Fastly VCL via "Fastly infra (Pulumi)"), on
+# manual dispatch, and weekly to catch edge config drift between deploys.
+
+on:
+  workflow_run:
+    workflows: ["Deploy to GitHub Pages", "Fastly infra (Pulumi)"]
+    types: [completed]
+  workflow_dispatch:
+  schedule:
+    - cron: "17 12 * * 1" # Mondays 12:17 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    # On a workflow_run trigger, only proceed when the upstream deploy succeeded
+    # on main. This skips infra pull-request previews, which do not change the
+    # production edge. Manual and scheduled runs always proceed.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: ".nvmrc"
+
+      # The deploy job purges the edge as its last step, so by the time this runs
+      # the purge is done. Allow a brief settle for new objects to propagate from
+      # the origin before asserting; the tests also retry the cache checks.
+      - name: Let the deploy settle
+        if: github.event_name == 'workflow_run'
+        run: sleep 15
+
+      - name: Run edge verification
+        run: npm run test:edge

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Docs
+
+Reference documentation for tollmanz.com.
+
+- [edge-caching.md](edge-caching.md): how the site caches, compresses, and serves
+  content at the Fastly edge in front of GitHub Pages, and why
+- [edge-verification.md](edge-verification.md): the `tests/edge/` suite that
+  verifies that contract against the live edge after every deploy

--- a/docs/edge-caching.md
+++ b/docs/edge-caching.md
@@ -1,0 +1,192 @@
+# Edge caching, compression, and transport
+
+How tollmanz.com caches, compresses, and serves content at the edge, and why.
+The behavior described here is enforced by the test suite in `tests/edge/`
+(documented in [edge-verification.md](edge-verification.md)) and was shipped in
+PRs #49, #50, and #51.
+
+## The problem
+
+The site is static, built by Eleventy and published to GitHub Pages. GitHub
+Pages labels every response `Cache-Control: max-age=600`. That single blanket
+value is wrong in two opposite directions at once:
+
+- ten minutes is too long for a stable-URL asset: edit `main.css` and a returning
+  visitor can keep the old stylesheet for up to ten minutes, so a rollout is not
+  instant
+- ten minutes is too short for an asset whose URL already changes on every edit:
+  a content-hashed file could be cached forever, but GitHub Pages still expires
+  it in ten minutes
+
+GitHub Pages exposes no per-path cache configuration, so the fix lives at the
+CDN.
+
+## The architecture
+
+A request passes through two independent Fastly layers before it reaches the
+HTML:
+
+```
+client -> Fastly (this project's service) -> GitHub Pages (itself Fastly) -> origin storage
+```
+
+This project controls only the first Fastly service, configured as code with
+Pulumi in `infra/`. It fronts GitHub Pages as the CDN and TLS terminator. The
+backend connects to `tollmanz.github.io` (whose TLS cert covers `*.github.io`)
+but sends `Host: www.tollmanz.com` via `overrideHost`, which selects this repo's
+site and avoids a redirect. The `iad-va-us` shield POP concentrates origin
+fetches so most edge POPs fill from the shield rather than from GitHub Pages.
+
+Two mechanisms produce the caching behavior:
+
+- content fingerprinting at build time, so assets that change get a new URL
+- a Fastly fetch snippet that rewrites the cache headers per asset class, so each
+  class gets the policy it should have rather than the blanket `max-age=600`
+
+## Cache-Control by asset class
+
+`infra/snippets/cache-control-fetch.vcl` runs in `vcl_fetch` and rewrites both
+Fastly's own object lifetime (`beresp.ttl`) and the browser-facing
+`Cache-Control`. The edge holds every class for a year and is kept fresh by a
+purge on each deploy, so a long edge TTL never serves stale content. The browser
+gets a different policy per class.
+
+| Class                       | Matches                                                           | Browser Cache-Control                 | Edge TTL                          |
+| --------------------------- | ----------------------------------------------------------------- | ------------------------------------- | --------------------------------- |
+| Fingerprinted CSS/JS, fonts | `.<hash>.css`, `.<hash>.js`, `.woff2`, `.ttf`, `.otf`, `.eot`     | `public, max-age=31536000, immutable` | 1 year                            |
+| Images, favicon             | `.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.avif`, `.svg`, `.ico` | `public, max-age=604800` (1 week)     | 1 year                            |
+| HTML, feed, sitemap         | everything else                                                   | `public, max-age=0, must-revalidate`  | 1 year                            |
+| Errors                      | any response with status >= 400                                   | passed through unchanged              | 1s (hashed assets) or 30s (other) |
+
+The reasoning per class:
+
+- fingerprinted assets are content-addressed, so the URL changes whenever the
+  bytes change. They are safe to cache forever and never revalidate, even on a
+  manual reload, which is what `immutable` instructs
+- images and the favicon have stable URLs that change rarely. A week in the
+  browser is a reasonable default; rename the file to bust the cache for an image
+  that must change sooner
+- HTML, the feed, and the sitemap have stable URLs whose contents change in
+  place. `max-age=0, must-revalidate` makes the browser revalidate on every
+  navigation, and the edge answers with a 304 from the GitHub Pages ETag until a
+  deploy purges it, so a change appears on the next navigation
+- an error is never pinned. A freshly-deployed hashed asset can 404 transiently
+  while the origin propagates, and the browser will not re-request an
+  immutable-by-URL stylesheet, so those 404s expire in 1s to avoid a visible
+  unstyled window; other errors expire in 30s
+
+`immutable` belongs only on content-addressed URLs. It is never applied to HTML,
+where it would freeze a stale page in the browser with no way to revalidate.
+
+## Content fingerprinting
+
+`src/_data/assets.js` is the single source of truth for asset URLs. It reads each
+CSS source, takes a sha256 of the bytes, keeps the first 12 hex characters, and
+exposes a URL of the form `/css/<name>.<hash>.css`. Two consumers read that map
+so the reference and the file can never drift:
+
+- `src/css/css.11tydata.js` sets each stylesheet's output `permalink` to its
+  hashed path, and throws an actionable build error if a stylesheet is added
+  without registering it in `assets.js`
+- `src/_includes/head.njk` writes the matching `<link>`
+
+Any edit to a CSS source changes its hash, which changes its output URL, which
+busts every cache the instant a new build ships. Minification is deterministic,
+so hashing the source guarantees a new URL whenever the delivered bytes change.
+The font files already carry content-hash filenames, so they need no build step;
+the VCL gives them the immutable policy by file extension.
+
+## Compression
+
+GitHub Pages serves gzip or identity but never brotli, and Fastly only compresses
+content it receives uncompressed. The setup in `infra/index.ts`:
+
+- `productEnablement.brotliCompression = true` enables Fastly's Brotli product.
+  This also makes Fastly's Accept-Encoding normalization keep the `br` token
+  instead of collapsing it to gzip
+- `infra/snippets/force-identity-fetch.vcl` unsets `bereq.http.Accept-Encoding` on
+  both `miss` and `pass`, so the origin always returns identity and Fastly has
+  uncompressed bytes to work with
+- the `gzips` block lists the content types and extensions to compress
+
+The edge then compresses to brotli for a capable client and gzip for the rest,
+varying on `Accept-Encoding`. Already-compressed types such as woff2 are not in
+the list, so they are served as-is rather than re-compressed. Savings over gzip
+are modest on a site this small (roughly 6 to 7 percent), but brotli is the
+better choice for any client that accepts it.
+
+## Transport and security
+
+The same Fastly service sets the rest of the edge behavior:
+
+- HTTP/2 and HTTP/3 are enabled (`http3: true`). HTTP/3 is advertised through the
+  `alt-svc` header so clients upgrade on a later connection
+- TLS 1.3 and TLS 1.2 are both accepted. TLS 1.3 session resumption and 0-RTT
+  early data are supported, so a returning client skips the full handshake and
+  can send its first request a round trip early
+- HSTS is set to `max-age=31557600` (one year) on responses
+- HTTP is upgraded to HTTPS with a 301 (`forceSsl`)
+- the apex `tollmanz.com` is redirected to the canonical `www.tollmanz.com` with
+  a 301 that preserves the path and query, synthesized at the edge from the
+  `apex-to-www-recv.vcl` and `apex-to-www-error.vcl` snippets
+
+## How a deploy reaches the edge
+
+Two pipelines fire on a push to `main`, each owning one half of the contract:
+
+- `.github/workflows/pages.yml` builds the site and deploys it to GitHub Pages on
+  any push to `main`, then runs `purge_all` against Fastly as its last step
+- `.github/workflows/infra.yml` runs `pulumi up` when `infra/**` changes on a push
+  to `main`, and `pulumi preview` on pull requests. The `site` resource is
+  `protect: true`, which blocks replace and delete but allows the in-place updates
+  these snippets need
+
+The cache snippet runs on every origin fill, so a newly-filled object always gets
+the current policy. An object cached just before a config change keeps its prior
+TTL until it expires or is purged. After a site deploy the `purge_all` clears the
+edge, so everything refills under the current VCL within seconds. An infra-only
+change does not trigger the Pages purge, so after one either rely on the old
+objects' natural expiry (the prior `max-age=600`, about ten minutes) or run a
+one-time `purge_all` for instant convergence.
+
+## Known tradeoffs
+
+These were identified in review and accepted; the test suite validates the
+production contract regardless of them:
+
+- images are not fingerprinted. `src/media` is passthrough-copied with stable
+  filenames, so an in-place image edit is invisible to returning visitors for up
+  to a week. Rename the file to force an update sooner
+- the HTML edge TTL is a year, kept correct only by the deploy purge. A missed
+  purge could strand stale HTML at the edge with no natural expiry until the next
+  deploy
+- the CSS hash covers the raw source, not the minified bytes that ship. The two
+  diverge only if a clean-css version or config change alters the output without
+  any CSS edit, which always co-occurs with a deploy
+- the dev server computes the CSS hash once at startup, so it serves a stale
+  hashed URL after a CSS edit until restarted. Production is unaffected because CI
+  always does a fresh single-pass build
+
+## Verify by hand
+
+```sh
+# Cache-Control per class
+curl -sI https://www.tollmanz.com/ | grep -i cache-control            # max-age=0, must-revalidate
+curl -sI https://www.tollmanz.com/favicon.ico | grep -i cache-control # max-age=604800
+CSS=$(curl -s https://www.tollmanz.com/ | grep -oE '/css/[a-z-]+\.[0-9a-f]+\.css' | head -1)
+curl -sI "https://www.tollmanz.com${CSS}" | grep -i cache-control     # immutable
+
+# 304 revalidation
+ETAG=$(curl -sI https://www.tollmanz.com/ | awk 'tolower($1)=="etag:"{print $2}' | tr -d '\r')
+curl -sI -H "If-None-Match: $ETAG" https://www.tollmanz.com/ | head -1 # 304
+
+# Compression
+curl -sI -H 'Accept-Encoding: br' https://www.tollmanz.com/ | grep -i content-encoding   # br
+curl -sI -H 'Accept-Encoding: gzip' https://www.tollmanz.com/ | grep -i content-encoding # gzip
+
+# HTTP/3 advertisement and TLS 0-RTT
+curl -sI https://www.tollmanz.com/ | grep -i alt-svc                  # h3=":443"
+openssl s_client -connect www.tollmanz.com:443 -tls1_3 -sess_out /tmp/s.pem < /dev/null >/dev/null 2>&1
+printf 'GET / HTTP/1.1\r\nHost: www.tollmanz.com\r\nConnection: close\r\n\r\n' > /tmp/req.txt
+openssl s_client -connect www.tollmanz.com:443 -sess_in /tmp/s.pem -early_data /tmp/req.txt 2>&1 | grep 'Early data'
+```

--- a/docs/edge-verification.md
+++ b/docs/edge-verification.md
@@ -1,0 +1,81 @@
+# Edge verification suite
+
+`tests/edge/` is a black-box smoke test of the live edge. It asserts the
+contract documented in [edge-caching.md](edge-caching.md) against a running host,
+so it catches a regression in the Fastly config, the build, or GitHub Pages that
+unit tests cannot see. It runs after every deploy and on a weekly schedule.
+
+## What it checks
+
+| File                         | Checks                                                                                                                                 |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `cache-control.test.js`      | Cache-Control per asset class (HTML, feed, sitemap, fingerprinted CSS, fonts, favicon); a 404 is never immutable                       |
+| `revalidation.test.js`       | HTML carries an ETag; a conditional request returns 304                                                                                |
+| `compression.test.js`        | brotli, gzip, and identity negotiation; brotli preferred; Vary on Accept-Encoding; fonts not re-compressed; brotli shrinks the payload |
+| `protocols.test.js`          | HTTP/2 negotiated; HTTP/3 advertised via alt-svc; a real HTTP/3 round trip when the runner's curl supports it                          |
+| `tls.test.js`                | TLS 1.3 and TLS 1.2 accepted; session resumption; 0-RTT early data accepted                                                            |
+| `redirects-security.test.js` | HTTP upgrades to HTTPS; apex redirects to www preserving the path; HSTS set with a long max-age                                        |
+
+## Running it
+
+```sh
+npm run test:edge                                   # against production
+EDGE_BASE_URL=https://staging.example.com npm run test:edge
+```
+
+The suite needs no npm dependencies. It uses the Node test runner with `curl` and
+`openssl`, all present on GitHub-hosted runners and macOS. `EDGE_BASE_URL`
+defaults to `https://www.tollmanz.com`; override it to point at another host. The
+apex-redirect tests run only when the base host is a `www` subdomain.
+
+## Design notes
+
+- requests go through `curl`, not Node's `fetch`. `fetch` transparently
+  decompresses responses and rewrites the Content-Encoding and Content-Length
+  headers, which would hide exactly what the compression tests assert. `curl`,
+  without `--compressed`, reports the headers and on-the-wire byte count as the
+  edge sent them
+- TLS properties (protocol versions, resumption, 0-RTT) are not visible to an
+  HTTP client, so those tests drive `openssl s_client`. It runs with stdin set to
+  `/dev/null` so it completes the handshake, prints its summary, and exits;
+  feeding it stdin through a pipe makes it block until the timeout instead
+- fingerprinted CSS and font URLs carry a content hash that changes on every
+  edit, so `lib/site.js` discovers them from the live HTML rather than hard-coding
+  them
+- the cache assertions retry a few times (`lib/retry.js`). Right after a deploy
+  the edge can briefly serve a transient state while a new object propagates from
+  the origin; the contract converges within seconds
+
+## HTTP/3
+
+The controllable contract is the `alt-svc` advertisement, which the
+`http3: true` Fastly setting produces, and that assertion always runs. A real
+HTTP/3 round trip needs a curl built with HTTP/3, which GitHub-hosted runners do
+not ship, so that one test skips there rather than failing. To exercise a real h3
+connection locally, run the suite with an HTTP/3-capable curl on `PATH` (for
+example the `ymuski/curl-http3` Docker image); the test detects support and runs
+automatically.
+
+## In CI
+
+`.github/workflows/edge-verify.yml` runs the suite:
+
+- after `Deploy to GitHub Pages` or `Fastly infra (Pulumi)` completes
+  successfully on `main`, via `workflow_run`. Infra pull-request previews are
+  skipped, since they do not change the production edge
+- on manual dispatch
+- weekly, to catch edge config drift between deploys (a changed Fastly product
+  entitlement, an expired cert, a reverted setting)
+
+After a deploy it waits briefly for the purge and propagation to settle before
+asserting. A failure fails the workflow, so a broken edge contract surfaces as a
+red check on the run that caused it.
+
+## Extending it
+
+Add a new behavior as a `*.test.js` file under `tests/edge/`. Reuse the helpers
+in `lib/`: `request` and `bodySize` for HTTP, `handshake` / `sessionResumption` /
+`earlyData` for TLS, `discoverAssets` for fingerprinted URLs, and `retry` for any
+assertion that should tolerate brief post-deploy propagation. Keep assertions
+exact where the value is set by config (the Cache-Control strings come straight
+from the VCL), so a test failure points at the specific drift.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "prebuild": "npm run clean",
     "build": "eleventy",
     "dev": "eleventy --serve",
+    "test": "npm run test:edge",
+    "test:edge": "node --test \"tests/edge/**/*.test.js\"",
     "lint": "eslint .",
     "lint:check": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/tests/edge/cache-control.test.js
+++ b/tests/edge/cache-control.test.js
@@ -1,0 +1,81 @@
+// Cache-Control by asset class.
+//
+// Validates the policy in infra/snippets/cache-control-fetch.vcl: fingerprinted
+// CSS/JS and fonts are immutable, images and the favicon get a week, HTML and
+// the feed/sitemap revalidate every time, and a 404 is never pinned immutable.
+// See docs/edge-caching.md for the full contract.
+
+import { test, before } from "node:test";
+import assert from "node:assert/strict";
+import { config, cacheControl } from "./config.js";
+import { request } from "./lib/curl.js";
+import { discoverAssets } from "./lib/site.js";
+import { retry } from "./lib/retry.js";
+
+let assets;
+
+before(async () => {
+  assets = await discoverAssets();
+});
+
+test("homepage HTML is served and revalidates every navigation", async () => {
+  await retry(async () => {
+    const res = await request(`${config.baseUrl}/`);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers["cache-control"], cacheControl.revalidate);
+  });
+});
+
+test("the feed revalidates every navigation", async () => {
+  await retry(async () => {
+    const res = await request(`${config.baseUrl}/feed.xml`);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers["cache-control"], cacheControl.revalidate);
+  });
+});
+
+test("the sitemap revalidates every navigation", async () => {
+  await retry(async () => {
+    const res = await request(`${config.baseUrl}/sitemap.xml`);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers["cache-control"], cacheControl.revalidate);
+  });
+});
+
+test("fingerprinted CSS is immutable", async () => {
+  assert.ok(assets.cssUrl, "no fingerprinted stylesheet found in the homepage");
+  await retry(async () => {
+    const res = await request(assets.cssUrl);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers["cache-control"], cacheControl.immutable);
+  });
+});
+
+test("content-hashed fonts are immutable", async () => {
+  assert.ok(assets.fontUrl, "no woff2 font found in the homepage");
+  await retry(async () => {
+    const res = await request(assets.fontUrl);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers["cache-control"], cacheControl.immutable);
+  });
+});
+
+test("the favicon is cached a week", async () => {
+  await retry(async () => {
+    const res = await request(`${config.baseUrl}/favicon.ico`);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers["cache-control"], cacheControl.image);
+  });
+});
+
+test("a 404 is not pinned immutable", async () => {
+  const res = await request(
+    `${config.baseUrl}/this-path-does-not-exist-xyz123`
+  );
+  assert.equal(res.status, 404);
+  const cc = res.headers["cache-control"] || "";
+  assert.ok(
+    !cc.includes("immutable"),
+    `404 must never be immutable, got: ${cc}`
+  );
+});

--- a/tests/edge/compression.test.js
+++ b/tests/edge/compression.test.js
@@ -1,0 +1,82 @@
+// Edge compression negotiation.
+//
+// GitHub Pages serves gzip or identity but never brotli. Fastly strips the
+// backend Accept-Encoding (force-identity-fetch.vcl) so the origin returns
+// identity, then compresses at the edge to brotli or gzip to match the client.
+// These tests confirm the edge negotiates the right encoding, varies on it, and
+// leaves already-compressed assets alone. See docs/edge-caching.md.
+
+import { test, before } from "node:test";
+import assert from "node:assert/strict";
+import { config } from "./config.js";
+import { request, bodySize } from "./lib/curl.js";
+import { discoverAssets } from "./lib/site.js";
+
+let assets;
+
+before(async () => {
+  assets = await discoverAssets();
+});
+
+test("HTML is served brotli to a brotli-capable client", async () => {
+  const res = await request(`${config.baseUrl}/`, { acceptEncoding: "br" });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers["content-encoding"], "br");
+});
+
+test("HTML falls back to gzip when brotli is not accepted", async () => {
+  const res = await request(`${config.baseUrl}/`, { acceptEncoding: "gzip" });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers["content-encoding"], "gzip");
+});
+
+test("HTML is served identity when no encoding is accepted", async () => {
+  const res = await request(`${config.baseUrl}/`);
+  assert.equal(res.status, 200);
+  assert.equal(res.headers["content-encoding"], undefined);
+});
+
+test("the edge prefers brotli over gzip when both are accepted", async () => {
+  const res = await request(`${config.baseUrl}/`, {
+    acceptEncoding: "gzip, deflate, br",
+  });
+  assert.equal(res.headers["content-encoding"], "br");
+});
+
+test("compressible responses vary on Accept-Encoding", async () => {
+  const res = await request(`${config.baseUrl}/`, { acceptEncoding: "br" });
+  const vary = (res.headers["vary"] || "").toLowerCase();
+  assert.ok(
+    vary.includes("accept-encoding"),
+    `expected Vary to include Accept-Encoding, got: ${res.headers["vary"]}`
+  );
+});
+
+test("fingerprinted CSS is served brotli", async () => {
+  assert.ok(assets.cssUrl, "no fingerprinted stylesheet found");
+  const res = await request(assets.cssUrl, { acceptEncoding: "br" });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers["content-encoding"], "br");
+});
+
+test("already-compressed fonts are not re-compressed", async () => {
+  assert.ok(assets.fontUrl, "no woff2 font found");
+  const res = await request(assets.fontUrl, { acceptEncoding: "br, gzip" });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers["content-encoding"], undefined);
+});
+
+test("brotli meaningfully shrinks the HTML payload", async () => {
+  const identity = await bodySize(`${config.baseUrl}/`);
+  const brotli = await bodySize(`${config.baseUrl}/`, { acceptEncoding: "br" });
+  const gzip = await bodySize(`${config.baseUrl}/`, { acceptEncoding: "gzip" });
+  assert.ok(identity > 0, "could not measure identity size");
+  assert.ok(
+    brotli < identity,
+    `brotli (${brotli}) should be smaller than identity (${identity})`
+  );
+  assert.ok(
+    brotli <= gzip,
+    `brotli (${brotli}) should be no larger than gzip (${gzip})`
+  );
+});

--- a/tests/edge/config.js
+++ b/tests/edge/config.js
@@ -1,0 +1,29 @@
+// Shared configuration for the edge verification suite.
+//
+// The suite asserts the live production contract documented in
+// docs/edge-caching.md, so it points at the Fastly-fronted origin by default.
+// Override EDGE_BASE_URL to run it against a different host (a staging Fastly
+// service, say). The apex redirect test only runs when the base host is the www
+// subdomain, since that is the only configuration where the redirect applies.
+
+const rawBase = process.env.EDGE_BASE_URL || "https://www.tollmanz.com";
+const baseUrl = rawBase.replace(/\/+$/, "");
+const { hostname } = new URL(baseUrl);
+
+export const config = {
+  baseUrl,
+  host: hostname,
+  // www.tollmanz.com -> tollmanz.com. Used by the apex-to-www redirect test.
+  apexHost: hostname.replace(/^www\./, ""),
+  isWww: hostname.startsWith("www."),
+};
+
+// Cache-Control values the Fastly fetch snippet writes per asset class. These
+// strings are set verbatim in infra/snippets/cache-control-fetch.vcl, so an
+// exact-string assertion validates the VCL output rather than a loose set of
+// directives.
+export const cacheControl = {
+  immutable: "public, max-age=31536000, immutable",
+  revalidate: "public, max-age=0, must-revalidate",
+  image: "public, max-age=604800",
+};

--- a/tests/edge/lib/curl.js
+++ b/tests/edge/lib/curl.js
@@ -1,0 +1,136 @@
+// HTTP helpers built on curl rather than Node's fetch.
+//
+// Native fetch (undici) transparently decompresses responses and rewrites the
+// Content-Encoding and Content-Length headers, which would hide the exact thing
+// the compression tests assert. curl, invoked without --compressed, reports the
+// response headers and on-the-wire byte count exactly as the edge sent them.
+
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+
+const TIMEOUT_MS = 25000;
+const MAX_BUFFER = 16 * 1024 * 1024;
+
+// Parse a raw curl header dump (status line plus headers) into a structured
+// response. A dump can contain more than one HTTP message (a 1xx informational
+// prelude such as 103 Early Hints, then the final response); the last status
+// line and the headers that follow it win.
+function parseHead(raw) {
+  let status = 0;
+  let httpVersion = "";
+  let headers = {};
+  for (const line of raw.split("\n")) {
+    const trimmed = line.replace(/\r$/, "");
+    const statusMatch = trimmed.match(/^HTTP\/(\S+)\s+(\d{3})/);
+    if (statusMatch) {
+      httpVersion = statusMatch[1];
+      status = Number(statusMatch[2]);
+      headers = {};
+      continue;
+    }
+    const colon = trimmed.indexOf(":");
+    if (colon > 0) {
+      const name = trimmed.slice(0, colon).trim().toLowerCase();
+      const value = trimmed.slice(colon + 1).trim();
+      headers[name] = name in headers ? `${headers[name]}, ${value}` : value;
+    }
+  }
+  return { status, httpVersion, headers };
+}
+
+function buildArgs(target, opts) {
+  const { acceptEncoding, ifNoneMatch, http, headers = {} } = opts;
+  // -sS: quiet but show errors. -o /dev/null: discard the body. -D -: dump
+  // response headers to stdout. No -L, so redirects are observed, not followed.
+  const args = ["-sS", "-o", "/dev/null", "-D", "-", "--max-time", "25"];
+  // curl sends no Accept-Encoding unless asked, so the origin returns identity
+  // by default. A caller opts into compression by passing acceptEncoding.
+  if (acceptEncoding) args.push("-H", `Accept-Encoding: ${acceptEncoding}`);
+  if (ifNoneMatch) args.push("-H", `If-None-Match: ${ifNoneMatch}`);
+  for (const [name, value] of Object.entries(headers)) {
+    args.push("-H", `${name}: ${value}`);
+  }
+  if (http === 2) args.push("--http2");
+  if (http === "1.1") args.push("--http1.1");
+  args.push(target);
+  return args;
+}
+
+// Issue a GET and return { status, httpVersion, headers }. The body is
+// discarded; only the response metadata is inspected.
+export async function request(target, opts = {}) {
+  const { stdout } = await run("curl", buildArgs(target, opts), {
+    timeout: TIMEOUT_MS,
+    maxBuffer: MAX_BUFFER,
+  });
+  return parseHead(stdout);
+}
+
+// Return the number of bytes transferred for the body of a GET. Without
+// --compressed this is the on-the-wire size, so it reflects the compressed
+// payload when acceptEncoding asks the edge to compress.
+export async function bodySize(target, { acceptEncoding } = {}) {
+  const args = [
+    "-sS",
+    "-o",
+    "/dev/null",
+    "-w",
+    "%{size_download}",
+    "--max-time",
+    "25",
+  ];
+  if (acceptEncoding) args.push("-H", `Accept-Encoding: ${acceptEncoding}`);
+  args.push(target);
+  const { stdout } = await run("curl", args, {
+    timeout: TIMEOUT_MS,
+    maxBuffer: MAX_BUFFER,
+  });
+  return Number.parseInt(stdout.trim(), 10);
+}
+
+// Fetch a text body (decompressed). Used to discover fingerprinted asset URLs
+// from the rendered HTML.
+export async function fetchText(target) {
+  const { stdout } = await run(
+    "curl",
+    ["-sS", "--compressed", "--max-time", "25", target],
+    { timeout: TIMEOUT_MS, maxBuffer: MAX_BUFFER }
+  );
+  return stdout;
+}
+
+// Whether the runner's curl was built with HTTP/3 support. GitHub-hosted
+// runners ship a curl without it, so the real-h3 round trip skips there and the
+// alt-svc advertisement carries the HTTP/3 assertion instead.
+export function curlSupportsHttp3() {
+  try {
+    const version = execFileSync("curl", ["--version"], { encoding: "utf8" });
+    return /\bHTTP3\b/i.test(version);
+  } catch {
+    return false;
+  }
+}
+
+// Attempt an HTTP/3-only round trip. Returns the negotiated http version string
+// (e.g. "3") on success. Throws if curl lacks HTTP/3 or the connection fails.
+export async function http3Request(target) {
+  const { stdout } = await run(
+    "curl",
+    [
+      "-sS",
+      "--http3-only",
+      "-o",
+      "/dev/null",
+      "-w",
+      "%{http_version} %{http_code}",
+      "--max-time",
+      "25",
+      target,
+    ],
+    { timeout: TIMEOUT_MS, maxBuffer: MAX_BUFFER }
+  );
+  const [httpVersion, status] = stdout.trim().split(/\s+/);
+  return { httpVersion, status: Number(status) };
+}

--- a/tests/edge/lib/retry.js
+++ b/tests/edge/lib/retry.js
@@ -1,0 +1,22 @@
+// Retry an async assertion a few times before giving up.
+//
+// Right after a deploy the edge can briefly serve a transient state: a
+// freshly-fingerprinted asset whose origin object has not finished propagating,
+// or an old object cached just before a VCL change. The contract converges
+// within seconds, so the cache assertions retry rather than fail on the first
+// transient miss.
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+export async function retry(fn, { tries = 4, delayMs = 3000 } = {}) {
+  let lastErr;
+  for (let attempt = 1; attempt <= tries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt < tries) await sleep(delayMs);
+    }
+  }
+  throw lastErr;
+}

--- a/tests/edge/lib/site.js
+++ b/tests/edge/lib/site.js
@@ -1,0 +1,24 @@
+// Discover fingerprinted asset URLs from the rendered homepage.
+//
+// CSS and font filenames carry a content hash that changes on every content
+// edit, so the suite cannot hard-code them. It reads the live HTML once and
+// pulls a hashed stylesheet and a woff2 font out of it, then the cache tests
+// assert the immutable policy against whatever the current build shipped.
+
+import { config } from "../config.js";
+import { fetchText } from "./curl.js";
+
+let cached;
+
+export async function discoverAssets() {
+  if (cached) return cached;
+  const html = await fetchText(`${config.baseUrl}/`);
+  const css = html.match(/\/css\/[a-z0-9-]+\.[0-9a-f]{8,}\.css/i);
+  const font = html.match(/\/fonts\/[A-Za-z0-9._-]+\.woff2/);
+  cached = {
+    html,
+    cssUrl: css ? `${config.baseUrl}${css[0]}` : null,
+    fontUrl: font ? `${config.baseUrl}${font[0]}` : null,
+  };
+  return cached;
+}

--- a/tests/edge/lib/tls.js
+++ b/tests/edge/lib/tls.js
@@ -1,0 +1,103 @@
+// TLS helpers built on the openssl s_client CLI.
+//
+// These probe properties an HTTP client cannot observe: which protocol versions
+// the edge accepts, whether it resumes a prior session, and whether it accepts
+// TLS 1.3 0-RTT early data. openssl is present on GitHub-hosted runners and
+// macOS, and version 3.x supports -early_data.
+//
+// s_client is run with stdin set to /dev/null (stdio "ignore"). With an empty
+// stdin it sees EOF immediately, completes the handshake, prints its session
+// summary, and exits. Feeding it stdin through a pipe instead (the child_process
+// input option) makes it block on the socket until the timeout, so it is
+// avoided here.
+
+import { spawn } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TIMEOUT_MS = 20000;
+
+// s_client exits non-zero in ordinary flows (the peer closing the connection,
+// for one), so output is captured regardless of exit status and the caller
+// decides success from the handshake summary it parses.
+function openssl(args) {
+  return new Promise(resolve => {
+    const child = spawn("openssl", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let out = "";
+    const collect = chunk => {
+      out += chunk;
+    };
+    child.stdout.on("data", collect);
+    child.stderr.on("data", collect);
+    const timer = setTimeout(() => child.kill("SIGKILL"), TIMEOUT_MS);
+    const done = () => {
+      clearTimeout(timer);
+      resolve(out);
+    };
+    child.on("close", done);
+    child.on("error", done);
+  });
+}
+
+function connect(host, ...extra) {
+  return ["s_client", "-connect", `${host}:443`, "-servername", host, ...extra];
+}
+
+// Open a single connection and report the negotiated protocol and cipher.
+// version is an openssl flag such as "-tls1_3" or "-tls1_2"; omit it to let the
+// edge pick.
+export async function handshake(host, version) {
+  const out = await openssl(connect(host, ...(version ? [version] : [])));
+  const protocol = (out.match(/Protocol\s*:\s*(\S+)/) || [])[1] || "";
+  return {
+    out,
+    protocol,
+    cipher: (out.match(/Cipher\s*:\s*(\S+)/) || [])[1] || "",
+    connected: protocol !== "" && /Verify return code: 0/.test(out),
+  };
+}
+
+function withTempDir(fn) {
+  const dir = mkdtempSync(join(tmpdir(), "edge-tls-"));
+  return Promise.resolve(fn(dir)).finally(() =>
+    rmSync(dir, { recursive: true, force: true })
+  );
+}
+
+// Capture a TLS 1.3 session ticket, then reconnect with it and report whether
+// the edge resumed the session.
+export async function sessionResumption(host) {
+  return withTempDir(async dir => {
+    const sess = join(dir, "sess.pem");
+    await openssl(connect(host, "-tls1_3", "-sess_out", sess));
+    const out = await openssl(connect(host, "-sess_in", sess));
+    return { reused: /Reused, TLSv1\.\d/.test(out), out };
+  });
+}
+
+// Capture a fresh TLS 1.3 session ticket (separate from the resumption probe,
+// since tickets can be single-use), then resume it sending an HTTP request as
+// 0-RTT early data and report whether the edge accepted it.
+export async function earlyData(host) {
+  return withTempDir(async dir => {
+    const sess = join(dir, "sess.pem");
+    const reqFile = join(dir, "req.txt");
+    writeFileSync(
+      reqFile,
+      `GET / HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`
+    );
+    await openssl(connect(host, "-tls1_3", "-sess_out", sess));
+    const out = await openssl(
+      connect(host, "-sess_in", sess, "-early_data", reqFile)
+    );
+    const maxMatch = out.match(/Max Early Data:\s*(\d+)/);
+    return {
+      accepted: /Early data was accepted/.test(out),
+      maxEarlyData: maxMatch ? Number(maxMatch[1]) : 0,
+      out,
+    };
+  });
+}

--- a/tests/edge/protocols.test.js
+++ b/tests/edge/protocols.test.js
@@ -1,0 +1,36 @@
+// HTTP protocol support.
+//
+// The Fastly service enables HTTP/2 and HTTP/3 (http3: true in infra/index.ts).
+// The h3 advertisement via alt-svc is the controllable contract and is always
+// asserted; a real HTTP/3 round trip is attempted only when the runner's curl
+// was built with HTTP/3 (GitHub-hosted runners ship one without it).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { config } from "./config.js";
+import { request, curlSupportsHttp3, http3Request } from "./lib/curl.js";
+
+test("HTTP/2 is negotiated", async () => {
+  const res = await request(`${config.baseUrl}/`, { http: 2 });
+  assert.equal(res.status, 200);
+  assert.equal(res.httpVersion, "2");
+});
+
+test("HTTP/3 is advertised via alt-svc", async () => {
+  const res = await request(`${config.baseUrl}/`);
+  const altSvc = res.headers["alt-svc"] || "";
+  assert.ok(
+    /h3(-\d+)?=/.test(altSvc),
+    `expected alt-svc to advertise h3, got: ${altSvc}`
+  );
+});
+
+test(
+  "an HTTP/3 round trip succeeds",
+  { skip: curlSupportsHttp3() ? false : "curl built without HTTP/3 support" },
+  async () => {
+    const res = await http3Request(`${config.baseUrl}/`);
+    assert.equal(res.status, 200);
+    assert.equal(res.httpVersion, "3");
+  }
+);

--- a/tests/edge/redirects-security.test.js
+++ b/tests/edge/redirects-security.test.js
@@ -1,0 +1,49 @@
+// Redirects and transport security.
+//
+// Fastly forces HTTPS (force_ssl), redirects the apex to the canonical www host
+// (apex-to-www snippets), and sets HSTS on responses. These keep every request
+// on the canonical, encrypted origin. See docs/edge-caching.md.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { config } from "./config.js";
+import { request } from "./lib/curl.js";
+
+const HSTS_MIN_AGE = 31536000; // one year
+
+test("http upgrades to https", async () => {
+  const httpUrl = `${config.baseUrl.replace(/^https:/, "http:")}/`;
+  const res = await request(httpUrl);
+  assert.equal(res.status, 301);
+  assert.ok(
+    (res.headers["location"] || "").startsWith("https://"),
+    `expected an https redirect, got: ${res.headers["location"]}`
+  );
+});
+
+test(
+  "the apex redirects to the canonical www host",
+  { skip: config.isWww ? false : "base host is not a www subdomain" },
+  async () => {
+    const res = await request(`https://${config.apexHost}/`);
+    assert.equal(res.status, 301);
+    assert.equal(res.headers["location"], `https://${config.host}/`);
+  }
+);
+
+test("the apex redirect preserves the path", async () => {
+  if (!config.isWww) return;
+  const res = await request(`https://${config.apexHost}/feed.xml`);
+  assert.equal(res.status, 301);
+  assert.equal(res.headers["location"], `https://${config.host}/feed.xml`);
+});
+
+test("HSTS is set with a long max-age", async () => {
+  const res = await request(`${config.baseUrl}/`);
+  const hsts = res.headers["strict-transport-security"] || "";
+  const maxAge = Number((hsts.match(/max-age=(\d+)/) || [])[1] || 0);
+  assert.ok(
+    maxAge >= HSTS_MIN_AGE,
+    `expected HSTS max-age >= ${HSTS_MIN_AGE}, got: ${hsts}`
+  );
+});

--- a/tests/edge/revalidation.test.js
+++ b/tests/edge/revalidation.test.js
@@ -1,0 +1,32 @@
+// HTML conditional revalidation.
+//
+// HTML carries max-age=0, must-revalidate, so the browser revalidates on every
+// navigation. That stays cheap only because the edge answers a conditional
+// request with a 304 from the GitHub Pages ETag instead of resending the body.
+// These tests confirm the ETag is present and the 304 path works.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { config } from "./config.js";
+import { request } from "./lib/curl.js";
+import { retry } from "./lib/retry.js";
+
+test("HTML responses carry an ETag", async () => {
+  await retry(async () => {
+    const res = await request(`${config.baseUrl}/`);
+    assert.equal(res.status, 200);
+    assert.ok(res.headers["etag"], "HTML must carry an ETag to revalidate");
+  });
+});
+
+test("a conditional request for unchanged HTML returns 304", async () => {
+  await retry(async () => {
+    const first = await request(`${config.baseUrl}/`);
+    const etag = first.headers["etag"];
+    assert.ok(etag, "no ETag to revalidate against");
+    const conditional = await request(`${config.baseUrl}/`, {
+      ifNoneMatch: etag,
+    });
+    assert.equal(conditional.status, 304);
+  });
+});

--- a/tests/edge/tls.test.js
+++ b/tests/edge/tls.test.js
@@ -1,0 +1,43 @@
+// TLS configuration: protocol versions, session resumption, and 0-RTT.
+//
+// Resumption lets a returning client skip the full handshake; 0-RTT (TLS 1.3
+// early data) lets it send the first request inside the resumed handshake,
+// saving a round trip. Both are edge properties an HTTP client cannot see, so
+// these tests drive openssl s_client directly.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { config } from "./config.js";
+import { handshake, sessionResumption, earlyData } from "./lib/tls.js";
+
+test("TLS 1.3 is supported", async () => {
+  const res = await handshake(config.host, "-tls1_3");
+  assert.ok(res.connected, `TLS 1.3 handshake failed:\n${res.out.slice(-400)}`);
+  assert.equal(res.protocol, "TLSv1.3");
+});
+
+test("TLS 1.2 is supported for broad client compatibility", async () => {
+  const res = await handshake(config.host, "-tls1_2");
+  assert.ok(res.connected, `TLS 1.2 handshake failed:\n${res.out.slice(-400)}`);
+  assert.equal(res.protocol, "TLSv1.2");
+});
+
+test("the edge resumes a prior TLS session", async () => {
+  const res = await sessionResumption(config.host);
+  assert.ok(
+    res.reused,
+    `expected the session to be reused:\n${res.out.slice(-400)}`
+  );
+});
+
+test("the edge accepts TLS 1.3 0-RTT early data", async () => {
+  const res = await earlyData(config.host);
+  assert.ok(
+    res.maxEarlyData > 0,
+    `expected a non-zero Max Early Data, got ${res.maxEarlyData}`
+  );
+  assert.ok(
+    res.accepted,
+    `expected early data to be accepted:\n${res.out.slice(-400)}`
+  );
+});


### PR DESCRIPTION
Adds a zero-dependency Node test runner suite under `tests/edge/` that black-box checks the live Fastly edge against the contract from PRs #49 to #51: Cache-Control per asset class, 304 revalidation, brotli/gzip negotiation, HTTP/2 and HTTP/3, TLS 1.2/1.3 with session resumption and 0-RTT, plus apex/HTTPS redirects and HSTS. It drives `curl` and `openssl` rather than `fetch` so auto-decompression cannot hide compression behavior, and discovers fingerprinted asset URLs from the live HTML. The suite runs after each deploy via `.github/workflows/edge-verify.yml` (workflow_run on the Pages and infra pipelines, plus manual dispatch and a weekly drift check) or locally with `npm run test:edge`. The `docs/` folder documents both the edge architecture (caching, compression, transport) and the suite itself.