### PR TITLE
feat: manage Honeycomb RUM boards via Pulumi

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,15 @@ OTEL_COLLECTOR_CONFIG=collector-config.yaml
 # the stack, never from the production key:
 #   cd infra/honeycomb && pulumi stack output localIngestKey --show-secrets
 HONEYCOMB_LOCAL_INGEST_KEY=
+
+# v1 Configuration Keys for the infra/honeycomb board tier, one per environment,
+# used when the matching manageProdBoard / manageLocalBoard stack config is true.
+# Boards are v1 resources that the v2 Management Key cannot manage, and this plan
+# blocks minting configuration keys via API, so create each by hand in the
+# Honeycomb UI (Environment settings -> API Keys, Manage Queries and Columns +
+# Manage Boards) in the matching environment and paste it here. See
+# infra/honeycomb/README.md.
+#   HONEYCOMB_CONFIG_KEY        tollmanz-com        (prod board)
+#   HONEYCOMB_LOCAL_CONFIG_KEY  tollmanz-com-local  (local board)
+HONEYCOMB_CONFIG_KEY=
+HONEYCOMB_LOCAL_CONFIG_KEY=

--- a/.github/workflows/honeycomb.yml
+++ b/.github/workflows/honeycomb.yml
@@ -97,3 +97,8 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           HONEYCOMB_KEY_ID: ${{ secrets.HONEYCOMB_KEY_ID }}
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET }}
+          # v1 Configuration Keys for the board tier, one per environment. Each
+          # is only required once its manage*Board stack config is flipped to
+          # true; harmless when unset otherwise. See infra/honeycomb/README.md.
+          HONEYCOMB_CONFIG_KEY: ${{ secrets.HONEYCOMB_CONFIG_KEY }}
+          HONEYCOMB_LOCAL_CONFIG_KEY: ${{ secrets.HONEYCOMB_LOCAL_CONFIG_KEY }}

--- a/infra/honeycomb/Pulumi.prod.yaml
+++ b/infra/honeycomb/Pulumi.prod.yaml
@@ -1,1 +1,1 @@
-{}
+{ config: { "tollmanz-com-honeycomb:manageLocalBoard": "true" } }

--- a/infra/honeycomb/Pulumi.prod.yaml
+++ b/infra/honeycomb/Pulumi.prod.yaml
@@ -1,1 +1,7 @@
-{ config: { "tollmanz-com-honeycomb:manageLocalBoard": "true" } }
+{
+  config:
+    {
+      "tollmanz-com-honeycomb:manageLocalBoard": "true",
+      "tollmanz-com-honeycomb:manageProdBoard": "true",
+    },
+}

--- a/infra/honeycomb/README.md
+++ b/infra/honeycomb/README.md
@@ -28,11 +28,12 @@ providers the board tier adds.
 
 ## RUM boards
 
-The board tier (issue #59) manages a compact Core Web Vitals board as code, one
-per environment: five query panels, one per metric (LCP, INP, CLS, FCP, TTFB),
-each a p75 over the last 7 days against the `tollmanz-com-web` dataset. It is a
-hand-built board rather than an import of the sprawling UI template, whose panels
-reference many UI-managed queries that `pulumi import` would leave unmanaged.
+The board tier (issue #59) manages a compact board named `Core Web Vitals
+(Pulumi-managed)` as code, one per environment: five query panels, one per metric
+(LCP, INP, CLS, FCP, TTFB), each a p75 over the last 7 days against the
+`tollmanz-com-web` dataset. It is a hand-built board rather than an import of the
+sprawling UI template, whose panels reference many UI-managed queries that
+`pulumi import` would leave unmanaged.
 
 Boards, queries, and query annotations are Honeycomb v1 API resources. They need
 a v1 Configuration Key scoped to one environment, not the v2 Management Key the
@@ -54,16 +55,40 @@ Each environment has its own flag, config key, and board:
 | `tollmanz-com`       | `manageProdBoard`  | `HONEYCOMB_CONFIG_KEY`       | `rumBoardIdProd`  |
 | `tollmanz-com-local` | `manageLocalBoard` | `HONEYCOMB_LOCAL_CONFIG_KEY` | `rumBoardIdLocal` |
 
-Prerequisite: the `tollmanz-com-web` dataset must already exist in the target
-environment (that environment has received at least one RUM event), or query
-creation fails with a dataset-not-found error. Prod has live RUM; for local, run
-the site with `RUM_MODE=local` at least once first.
+Prerequisite: every column the board queries must already exist in the target
+environment, because Honeycomb validates columns when a saved query is created
+(`missing unknown column or derived column "<name>"`). Columns are created by
+ingest, so the environment needs real RUM traffic first: run the site with
+`RUM_MODE=local` and browse it (see `local/otel/README.md`). Prod has live
+traffic and all five columns.
+
+`inp.value` is the one that bites. INP is only emitted after a qualifying user
+interaction, and synthetic or headless clicks generally do not produce one, so a
+local environment can have every other vital and still be missing INP. Seeding
+the column with a single event is enough to unblock query creation:
+
+```bash
+curl -X POST https://api.honeycomb.io/1/events/tollmanz-com-web \
+  -H "X-Honeycomb-Team: $HONEYCOMB_LOCAL_INGEST_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"inp","inp.value":120}'
+```
+
+Column types are inferred per environment from the first value seen, so they can
+differ between environments (`cls.value` is `integer` in prod, `float` in local).
+That is harmless for these queries, which reference columns by name, and it is
+why the columns are left to ingest rather than declared as Pulumi resources.
 
 To enable a board (prod shown; substitute the local flag and key for local):
 
 1. In the Honeycomb UI, switch to the target environment, open its settings ->
    API Keys, and create a Configuration Key. Grant it "Manage Queries and
-   Columns" and "Manage Boards" (or full permissions). Copy the key.
+   Columns" and "Manage Boards". The "Run Queries" permission is not needed: the
+   board tier only creates saved query specs, it never executes them, and that
+   permission is plan-gated. Verify a key with
+   `curl -H "X-Honeycomb-Team: $KEY" https://api.honeycomb.io/1/auth`, which
+   should report `boards: true` and `columns: true` for the right environment.
+   Copy the key.
 2. Set the matching env var in the repo-root `.env` and add it as a GitHub
    Actions repository secret of the same name.
 3. Turn the flag on for the stack, then apply:
@@ -74,9 +99,12 @@ To enable a board (prod shown; substitute the local flag and key for local):
    npm run up
    ```
 
-The pre-existing manually-created `Real User Monitoring (RUM)` board
-(`nUnmjid2hYb`, in `tollmanz-com-local`) is left untouched; delete it in the UI
-once the managed board covers what you need.
+Both environments already contain a hand-made 9-panel board named `Real User
+Monitoring (RUM)` (`uymoPQWt5Hh` in `tollmanz-com`, `nUnmjid2hYb` in
+`tollmanz-com-local`). The managed board carries a different name on purpose, so
+it coexists with those rather than adding a second board with an identical name.
+Both hand-made boards are left untouched; retire them in the UI, and rename the
+managed board, once it covers what you need.
 
 ## The prod ingest key never reaches the browser
 

--- a/infra/honeycomb/README.md
+++ b/infra/honeycomb/README.md
@@ -28,12 +28,25 @@ providers the board tier adds.
 
 ## RUM boards
 
-The board tier (issue #59) manages a compact board named `Core Web Vitals
-(Pulumi-managed)` as code, one per environment: five query panels, one per metric
-(LCP, INP, CLS, FCP, TTFB), each a p75 over the last 7 days against the
-`tollmanz-com-web` dataset. It is a hand-built board rather than an import of the
-sprawling UI template, whose panels reference many UI-managed queries that
-`pulumi import` would leave unmanaged.
+The board tier (issue #59) manages a board named `Real User Monitoring
+(Pulumi-managed)` as code, one per environment, in two sections against the
+`tollmanz-com-web` dataset:
+
+| Section         | Panels | Window                  | Content                                                  |
+| --------------- | ------ | ----------------------- | -------------------------------------------------------- |
+| Core Web Vitals | 5      | 7 day p75               | LCP, INP, CLS, FCP, TTFB, the window Google reports over |
+| RUM overview    | 9      | 2 hour, 10s granularity | Ported from the hand-made template board (see below)     |
+
+A full-width Markdown text panel titles each section, and every panel carries an
+explicit position on Honeycomb's 12 column grid, so the layout is deterministic
+rather than whatever order the API returns. The vitals sit on top, three to a
+row; the overview section below keeps the template board's own arrangement.
+
+The overview queries are reproduced as managed `Query` and `QueryAnnotation`
+resources rather than referenced by ID, so retiring the hand-made board cannot
+break this one. That is why the board is hand-built rather than a `pulumi
+import` of the template, whose panels point at UI-owned queries that import
+would leave unmanaged.
 
 Boards, queries, and query annotations are Honeycomb v1 API resources. They need
 a v1 Configuration Key scoped to one environment, not the v2 Management Key the
@@ -103,8 +116,11 @@ Both environments already contain a hand-made 9-panel board named `Real User
 Monitoring (RUM)` (`uymoPQWt5Hh` in `tollmanz-com`, `nUnmjid2hYb` in
 `tollmanz-com-local`). The managed board carries a different name on purpose, so
 it coexists with those rather than adding a second board with an identical name.
-Both hand-made boards are left untouched; retire them in the UI, and rename the
-managed board, once it covers what you need.
+
+The two boards are complementary and both are kept on purpose. The hand-made
+boards stay as they are, untouched and unmanaged, and the managed board's
+distinct name is what lets them sit side by side. Nothing here deletes or edits
+them.
 
 ## The prod ingest key never reaches the browser
 

--- a/infra/honeycomb/README.md
+++ b/infra/honeycomb/README.md
@@ -28,9 +28,9 @@ providers the board tier adds.
 
 ## RUM boards
 
-The board tier (issue #59) manages a board named `Real User Monitoring
-(Pulumi-managed)` as code, one per environment, in two sections against the
-`tollmanz-com-web` dataset:
+The board tier (issue #59) manages the `Real User Monitoring (RUM)` board as
+code, one per environment, in two sections against the `tollmanz-com-web`
+dataset:
 
 | Section         | Panels | Window                  | Content                                                  |
 | --------------- | ------ | ----------------------- | -------------------------------------------------------- |
@@ -43,10 +43,10 @@ rather than whatever order the API returns. The vitals sit on top, three to a
 row; the overview section below keeps the template board's own arrangement.
 
 The overview queries are reproduced as managed `Query` and `QueryAnnotation`
-resources rather than referenced by ID, so retiring the hand-made board cannot
-break this one. That is why the board is hand-built rather than a `pulumi
-import` of the template, whose panels point at UI-owned queries that import
-would leave unmanaged.
+resources rather than referenced by ID, so this board does not depend on any
+UI-owned query. That is also why it is hand-built rather than a `pulumi import`
+of the template board, whose panels pointed at queries import would have left
+unmanaged.
 
 Boards, queries, and query annotations are Honeycomb v1 API resources. They need
 a v1 Configuration Key scoped to one environment, not the v2 Management Key the
@@ -104,23 +104,21 @@ To enable a board (prod shown; substitute the local flag and key for local):
    Copy the key.
 2. Set the matching env var in the repo-root `.env` and add it as a GitHub
    Actions repository secret of the same name.
-3. Turn the flag on for the stack, then apply:
+3. Turn the flag on for the stack. Committing the flag is what enables the board;
+   CI applies it on push to `main`, so a local apply is optional:
 
    ```bash
    cd infra/honeycomb
    pulumi config set manageProdBoard true
-   npm run up
+   npm run up   # or let the honeycomb workflow apply it on merge
    ```
 
-Both environments already contain a hand-made 9-panel board named `Real User
-Monitoring (RUM)` (`uymoPQWt5Hh` in `tollmanz-com`, `nUnmjid2hYb` in
-`tollmanz-com-local`). The managed board carries a different name on purpose, so
-it coexists with those rather than adding a second board with an identical name.
-
-The two boards are complementary and both are kept on purpose. The hand-made
-boards stay as they are, untouched and unmanaged, and the managed board's
-distinct name is what lets them sit side by side. Nothing here deletes or edits
-them.
+Honeycomb's own template had created a hand-made 9-panel board, also named `Real
+User Monitoring (RUM)`, in both environments (`uymoPQWt5Hh` in `tollmanz-com`,
+`nUnmjid2hYb` in `tollmanz-com-local`). Both were deleted once their panels were
+reproduced in the overview section, so each environment has exactly one RUM
+board and it is fully managed here. Recreating either by hand would produce two
+boards with the same name, since Honeycomb keys boards by ID.
 
 ## The prod ingest key never reaches the browser
 

--- a/infra/honeycomb/README.md
+++ b/infra/honeycomb/README.md
@@ -48,6 +48,20 @@ UI-owned query. That is also why it is hand-built rather than a `pulumi import`
 of the template board, whose panels pointed at queries import would have left
 unmanaged.
 
+Seven of the nine overview queries are reproduced verbatim. Two were corrected,
+because the template was written for a generic web app rather than this one:
+
+- `Slowest Pages by Document Fetch` was `Slowest Requests by Endpoint`, filtering
+  `name` to fetch and XHR spans (`HTTP GET` and friends). This site makes no fetch
+  or XHR calls at all, and the RUM exporter's own request is excluded from
+  instrumentation, so nothing ever matched and the panel was permanently empty. It
+  now measures `documentFetch`, the navigation request, by `page.route`
+- `Top Landing Pages by Page Load` was `Top Landing Pages by Session Count`. The
+  Honeycomb web SDK mints a session id once per document with no persistence, so
+  every navigation on this multi-page site starts a new session. The query counts
+  document loads, and `COUNT_DISTINCT(session.id)` would return the same figure, so
+  only the label was wrong
+
 Boards, queries, and query annotations are Honeycomb v1 API resources. They need
 a v1 Configuration Key scoped to one environment, not the v2 Management Key the
 rest of this project uses. Two constraints shape how the keys are supplied:
@@ -88,9 +102,32 @@ curl -X POST https://api.honeycomb.io/1/events/tollmanz-com-web \
 ```
 
 Column types are inferred per environment from the first value seen, so they can
-differ between environments (`cls.value` is `integer` in prod, `float` in local).
-That is harmless for these queries, which reference columns by name, and it is
-why the columns are left to ingest rather than declared as Pulumi resources.
+differ between environments, and the type is not cosmetic. Honeycomb coerces
+incoming values to the column's type and substitutes `0` when coercion is not
+possible, so a numeric metric on the wrong type is corrupted at ingest rather
+than merely displayed oddly.
+
+`cls.value` is the one that matters. CLS is fractional, with the "good" and "poor"
+thresholds at 0.1 and 0.25, so an `integer` column truncates every score toward
+zero and makes `P75(cls.value)` meaningless. Prod had exactly that, and the column
+was corrected to `float`; local was already `float`. Data written to prod before
+the correction was coerced on the way in and is not recoverable by changing the
+type, which only governs later writes.
+
+`lcp.value`, `fcp.value`, and `inp.value` are still `integer` in prod. Those are
+whole-millisecond timings in the hundreds or thousands, so truncation is
+insignificant and they are left alone. Check the types before trusting a new
+environment's board:
+
+```bash
+curl -sS -H "X-Honeycomb-Team: $KEY" \
+  https://api.honeycomb.io/1/columns/tollmanz-com-web \
+  | jq -r '.[] | select(.key_name|endswith(".value")) | "\(.key_name) \(.type)"'
+```
+
+Columns are still left to ingest rather than declared as Pulumi resources, since a
+declared type would try to mutate whatever ingest already created. Fix a wrong
+type in the UI schema view, or with `PUT /1/columns/<dataset>/<id>`.
 
 To enable a board (prod shown; substitute the local flag and key for local):
 

--- a/infra/honeycomb/README.md
+++ b/infra/honeycomb/README.md
@@ -16,10 +16,67 @@ datasets are created on ingest, so the ingest key (with `createDatasets`) create
 it on the first telemetry it receives, named by the browser SDK's `serviceName`
 (`tollmanz-com-web`).
 
-Triggers and SLOs are intentionally omitted for now. They need a configuration
-key scoped to this environment rather than the team-level management key used
-here, so they are a clean drop-in later: add a second provider configured with
-that key and the trigger/SLO resources.
+Optionally, a curated Core Web Vitals board per environment (`tollmanz-com` and
+`tollmanz-com-local`). Boards are v1 API resources managed through a second
+provider authenticated with a v1 Configuration Key, each gated on its own stack
+config flag (`manageProdBoard`, `manageLocalBoard`; default off). See "RUM
+boards" below.
+
+Triggers and SLOs are intentionally omitted for now. Like boards they are v1
+resources, so they are a clean drop-in later using the same Configuration Key
+providers the board tier adds.
+
+## RUM boards
+
+The board tier (issue #59) manages a compact Core Web Vitals board as code, one
+per environment: five query panels, one per metric (LCP, INP, CLS, FCP, TTFB),
+each a p75 over the last 7 days against the `tollmanz-com-web` dataset. It is a
+hand-built board rather than an import of the sprawling UI template, whose panels
+reference many UI-managed queries that `pulumi import` would leave unmanaged.
+
+Boards, queries, and query annotations are Honeycomb v1 API resources. They need
+a v1 Configuration Key scoped to one environment, not the v2 Management Key the
+rest of this project uses. Two constraints shape how the keys are supplied:
+
+- minting a configuration key from the Management Key fails on this plan
+  (`access to this API is disabled: Error Creating Honeycomb API Key`), so each
+  key is created by hand in the Honeycomb UI, not by a `honeycombio.ApiKey`
+  resource
+- enablement is gated on committed flags, not on env-var presence, so board state
+  is deterministic across apply contexts: with one shared stack, keying on the
+  env var would let a local apply create a board and a CI apply without the key
+  delete it
+
+Each environment has its own flag, config key, and board:
+
+| Environment          | Flag               | Config key env var           | Board output      |
+| -------------------- | ------------------ | ---------------------------- | ----------------- |
+| `tollmanz-com`       | `manageProdBoard`  | `HONEYCOMB_CONFIG_KEY`       | `rumBoardIdProd`  |
+| `tollmanz-com-local` | `manageLocalBoard` | `HONEYCOMB_LOCAL_CONFIG_KEY` | `rumBoardIdLocal` |
+
+Prerequisite: the `tollmanz-com-web` dataset must already exist in the target
+environment (that environment has received at least one RUM event), or query
+creation fails with a dataset-not-found error. Prod has live RUM; for local, run
+the site with `RUM_MODE=local` at least once first.
+
+To enable a board (prod shown; substitute the local flag and key for local):
+
+1. In the Honeycomb UI, switch to the target environment, open its settings ->
+   API Keys, and create a Configuration Key. Grant it "Manage Queries and
+   Columns" and "Manage Boards" (or full permissions). Copy the key.
+2. Set the matching env var in the repo-root `.env` and add it as a GitHub
+   Actions repository secret of the same name.
+3. Turn the flag on for the stack, then apply:
+
+   ```bash
+   cd infra/honeycomb
+   pulumi config set manageProdBoard true
+   npm run up
+   ```
+
+The pre-existing manually-created `Real User Monitoring (RUM)` board
+(`nUnmjid2hYb`, in `tollmanz-com-local`) is left untouched; delete it in the UI
+once the managed board covers what you need.
 
 ## The prod ingest key never reaches the browser
 
@@ -48,10 +105,12 @@ the deployed site.
 
 The provider authenticates with a Honeycomb v2 Management Key pair:
 
-| Variable               | Used by                 | Source                |
-| ---------------------- | ----------------------- | --------------------- |
-| `HONEYCOMB_KEY_ID`     | Honeycomb provider auth | Management Key ID     |
-| `HONEYCOMB_KEY_SECRET` | Honeycomb provider auth | Management Key secret |
+| Variable                     | Used by                          | Source                                         |
+| ---------------------------- | -------------------------------- | ---------------------------------------------- |
+| `HONEYCOMB_KEY_ID`           | Honeycomb provider auth          | Management Key ID                              |
+| `HONEYCOMB_KEY_SECRET`       | Honeycomb provider auth          | Management Key secret                          |
+| `HONEYCOMB_CONFIG_KEY`       | Prod board (`manageProdBoard`)   | v1 Configuration Key, `tollmanz-com` env       |
+| `HONEYCOMB_LOCAL_CONFIG_KEY` | Local board (`manageLocalBoard`) | v1 Configuration Key, `tollmanz-com-local` env |
 
 Create the Management Key under Team settings -> API Keys -> Management Keys,
 with these scopes:
@@ -113,6 +172,8 @@ repository secrets:
 - `PULUMI_ACCESS_TOKEN`
 - `HONEYCOMB_KEY_ID`
 - `HONEYCOMB_KEY_SECRET`
+- `HONEYCOMB_CONFIG_KEY` (only once `manageProdBoard` is on)
+- `HONEYCOMB_LOCAL_CONFIG_KEY` (only once `manageLocalBoard` is on)
 
 ## First apply
 

--- a/infra/honeycomb/index.ts
+++ b/infra/honeycomb/index.ts
@@ -19,6 +19,16 @@ const environmentName = config.get("environmentName") ?? "tollmanz-com";
 const localEnvironmentName =
   config.get("localEnvironmentName") ?? "tollmanz-com-local";
 
+// Whether to manage the RUM boards (see the v1 board tier below). Gated on
+// committed flags, not on env-var presence, so board state is deterministic
+// across every apply context. The dataset is created on ingest and named by the
+// browser SDK's serviceName (see assets/rum/index.js, scripts/build-rum.mjs); it
+// carries the same name in both environments, scoped per environment by the
+// config key each board provider authenticates with.
+const manageProdBoard = config.getBoolean("manageProdBoard") ?? false;
+const manageLocalBoard = config.getBoolean("manageLocalBoard") ?? false;
+const datasetName = config.get("datasetName") ?? "tollmanz-com-web";
+
 // Production Honeycomb environment that holds browser RUM telemetry. In the
 // Environments and Services model datasets are created on ingest, so none is
 // declared here; the ingest key below creates it on the first telemetry it
@@ -57,6 +67,145 @@ const localIngest = new honeycombio.ApiKey("rum-local-ingest", {
   permissions: [{ createDatasets: true }],
 });
 
+// v1 board tier (see issue #59).
+//
+// Boards, queries, and query annotations are Honeycomb v1 API resources. They
+// need a v1 Configuration Key scoped to a single environment, not the v2
+// Management Key the provider above authenticates with. Minting a configuration
+// key from the Management Key fails on this plan ("access to this API is
+// disabled: Error Creating Honeycomb API Key"), so each key is created by hand
+// in the Honeycomb UI (Environment settings -> API Keys) and supplied out of
+// band via an env var rather than by a honeycombio.ApiKey resource.
+//
+// Enablement is gated on committed flags, not on env-var presence, so state is
+// deterministic across apply contexts: with one shared stack, keying on env-var
+// presence would let a local apply create a board and a CI apply without the key
+// delete it. Flip a flag only once its config key exists both in the repo-root
+// .env and as the matching GitHub Actions secret. See infra/honeycomb/README.md.
+
+// Core Web Vitals tracked on every board. WebVitalsInstrumentation emits each
+// metric as its own span carrying a `<metric>.value` field; p75 is the value
+// Google reports for Core Web Vitals.
+const vitals = [
+  {
+    key: "lcp",
+    label: "LCP p75",
+    description: "Largest Contentful Paint, 75th percentile (ms)",
+  },
+  {
+    key: "inp",
+    label: "INP p75",
+    description: "Interaction to Next Paint, 75th percentile (ms)",
+  },
+  {
+    key: "cls",
+    label: "CLS p75",
+    description: "Cumulative Layout Shift, 75th percentile",
+  },
+  {
+    key: "fcp",
+    label: "FCP p75",
+    description: "First Contentful Paint, 75th percentile (ms)",
+  },
+  {
+    key: "ttfb",
+    label: "TTFB p75",
+    description: "Time to First Byte, 75th percentile (ms)",
+  },
+];
+
+// Build a curated RUM board in one environment, authenticated with that
+// environment's v1 Configuration Key. `slug` (prod/local) keeps resource names
+// unique across the two boards. A compact hand-built board is preferred over
+// importing the sprawling template board (see issue #59): the template's panels
+// reference many UI-managed queries that `pulumi import` would leave unmanaged.
+function rumBoard(
+  slug: string,
+  configKey: string,
+  description: string
+): pulumi.Output<string> {
+  const provider = new honeycombio.Provider(`rum-${slug}-config`, {
+    apiKey: configKey,
+  });
+  const providerOpts = { provider };
+
+  const panels = vitals.map(v => {
+    const query = new honeycombio.Query(
+      `rum-${slug}-${v.key}`,
+      {
+        dataset: datasetName,
+        queryJson: JSON.stringify({
+          calculations: [{ op: "P75", column: `${v.key}.value` }],
+          time_range: 604800,
+        }),
+      },
+      providerOpts
+    );
+    const annotation = new honeycombio.QueryAnnotation(
+      `rum-${slug}-${v.key}`,
+      {
+        dataset: datasetName,
+        queryId: query.id,
+        name: v.label,
+        description: v.description,
+      },
+      providerOpts
+    );
+    return {
+      type: "query",
+      queryPanels: [
+        {
+          queryId: query.id,
+          queryAnnotationId: annotation.id,
+          queryStyle: "graph",
+        },
+      ],
+    };
+  });
+
+  const board = new honeycombio.FlexibleBoard(
+    `rum-${slug}-board`,
+    {
+      name: "Real User Monitoring (RUM)",
+      description,
+      panels,
+    },
+    providerOpts
+  );
+
+  return board.id;
+}
+
+// Read a required config key, failing fast with an actionable message so a
+// misconfigured apply errors loudly instead of deleting a board.
+function requireConfigKey(envVar: string, flag: string): string {
+  const key = process.env[envVar];
+  if (!key) {
+    throw new Error(
+      `${flag} is true but ${envVar} is not set. Create a v1 Configuration Key for the target environment in the Honeycomb UI, then set it in the repo-root .env locally or as a GitHub Actions secret in CI. See infra/honeycomb/README.md.`
+    );
+  }
+  return key;
+}
+
+let prodBoardId: pulumi.Output<string> | undefined;
+if (manageProdBoard) {
+  prodBoardId = rumBoard(
+    "prod",
+    requireConfigKey("HONEYCOMB_CONFIG_KEY", "manageProdBoard"),
+    "Core Web Vitals for tollmanz.com browser RUM (p75 over the last 7 days). Managed by infra/honeycomb (Pulumi)."
+  );
+}
+
+let localBoardId: pulumi.Output<string> | undefined;
+if (manageLocalBoard) {
+  localBoardId = rumBoard(
+    "local",
+    requireConfigKey("HONEYCOMB_LOCAL_CONFIG_KEY", "manageLocalBoard"),
+    "Core Web Vitals for tollmanz.com browser RUM, local testing environment (p75 over the last 7 days). Managed by infra/honeycomb (Pulumi)."
+  );
+}
+
 export const environmentId = environment.id;
 export const environmentSlug = environment.slug;
 export const localEnvironmentId = localEnvironment.id;
@@ -67,3 +216,8 @@ export const localEnvironmentSlug = localEnvironment.slug;
 // StackReference; `localIngestKey` is read by hand for the repo-root .env.
 export const ingestKey = pulumi.secret(ingest.key);
 export const localIngestKey = pulumi.secret(localIngest.key);
+
+// IDs of the curated RUM boards, when managed. Each is undefined until its flag
+// is enabled with the matching v1 Configuration Key present.
+export const rumBoardIdProd = prodBoardId;
+export const rumBoardIdLocal = localBoardId;

--- a/infra/honeycomb/index.ts
+++ b/infra/honeycomb/index.ts
@@ -311,11 +311,11 @@ const OVERVIEW_ORIGIN_Y = OVERVIEW_HEADING_Y + HEADING_HEIGHT;
 // environment's v1 Configuration Key. `slug` (prod/local) keeps resource names
 // unique across the two boards.
 //
-// The name deliberately differs from the hand-made `Real User Monitoring (RUM)`
-// template board that already exists in both environments, so the two coexist
-// unambiguously in the boards list. Honeycomb keys boards by ID and permits
-// duplicate names, so reusing that name would silently produce two similar-
-// looking boards in the same environment.
+// This is now the only RUM board in each environment. The hand-made template
+// board that Honeycomb created, also called `Real User Monitoring (RUM)`, was
+// deleted once its panels were reproduced in the overview section below, so the
+// name is free and there is one board per environment rather than two similar
+// ones.
 function rumBoard(
   slug: string,
   configKey: string,
@@ -425,7 +425,7 @@ function rumBoard(
   const board = new honeycombio.FlexibleBoard(
     `rum-${slug}-board`,
     {
-      name: "Real User Monitoring (Pulumi-managed)",
+      name: "Real User Monitoring (RUM)",
       description,
       panels,
     },

--- a/infra/honeycomb/index.ts
+++ b/infra/honeycomb/index.ts
@@ -114,11 +114,202 @@ const vitals = [
   },
 ];
 
+// The RUM overview section, ported from the hand-made `Real User Monitoring
+// (RUM)` board that Honeycomb's template created in both environments. Each
+// entry reproduces that board's saved query as a managed resource rather than
+// pointing at the UI-owned query by ID, so the whole board is code and nothing
+// breaks if the hand-made board is retired.
+//
+// These queries are environment-wide in the template (`__all__`); here they are
+// scoped to the one dataset the environment has, matching the vitals section.
+// Every column they reference exists in both environments. `position` preserves
+// the template's own arrangement, offset below the vitals section.
+//
+// They all use a 7200s (two hour) window at 10s granularity, as the template
+// did. That is deliberately shorter than the vitals section's 7 day p75, so the
+// two sections answer different questions: what is happening now, and what the
+// steady-state user experience looks like.
+const overview = [
+  {
+    key: "lcp-ratings",
+    label: "Largest Contentful Paint (LCP)",
+    description:
+      "Ratings based on the render time for the largest content on a page",
+    style: "combo",
+    position: { x: 0, y: 0, width: 4, height: 8 },
+    query: {
+      granularity: 10,
+      breakdowns: ["lcp.rating", "name"],
+      calculations: [{ op: "COUNT" }],
+      filters: [{ column: "name", op: "in", value: ["LCP", "lcp"] }],
+      orders: [{ op: "COUNT", order: "descending" }],
+      time_range: 7200,
+    },
+  },
+  {
+    key: "cls-ratings",
+    label: "Cumulative Layout Shift (CLS)",
+    description: "Ratings based on the stability of content layout on a page",
+    style: "combo",
+    position: { x: 4, y: 0, width: 4, height: 8 },
+    query: {
+      granularity: 10,
+      breakdowns: ["cls.rating", "name"],
+      calculations: [{ op: "COUNT" }],
+      filters: [{ column: "name", op: "in", value: ["CLS", "cls"] }],
+      orders: [{ op: "COUNT", order: "descending" }],
+      time_range: 7200,
+    },
+  },
+  {
+    key: "lcp-p75",
+    label: "Largest Contentful Paint P75",
+    description: "The 75th percentile for LCP",
+    style: "graph",
+    position: { x: 8, y: 0, width: 4, height: 4 },
+    query: {
+      granularity: 10,
+      calculations: [{ column: "lcp.value", op: "P75" }],
+      filters: [{ column: "name", op: "in", value: ["LCP", "lcp"] }],
+      orders: [{ column: "lcp.value", op: "P75", order: "descending" }],
+      time_range: 7200,
+    },
+  },
+  {
+    key: "cls-p75",
+    label: "Cumulative Layout Shift P75",
+    description: "The 75th percentile for CLS",
+    style: "graph",
+    position: { x: 0, y: 8, width: 4, height: 4 },
+    query: {
+      granularity: 10,
+      calculations: [{ column: "cls.value", op: "P75" }],
+      filters: [{ column: "name", op: "in", value: ["CLS", "cls"] }],
+      orders: [{ column: "cls.value", op: "P75", order: "descending" }],
+      time_range: 7200,
+    },
+  },
+  {
+    key: "events-by-type",
+    label: "Total Events by Type",
+    description: "Event types ranked by occurrence",
+    style: "combo",
+    position: { x: 4, y: 8, width: 4, height: 8 },
+    query: {
+      granularity: 10,
+      breakdowns: ["name"],
+      calculations: [{ op: "COUNT" }],
+      filters: [
+        { column: "meta.annotation_type", op: "!=", value: "span_event" },
+      ],
+      orders: [{ op: "COUNT", order: "descending" }],
+      limit: 100,
+      time_range: 7200,
+    },
+  },
+  {
+    key: "largest-resources",
+    label: "Largest Resource Requests",
+    description:
+      "The largest resource requests ranked by the average length of their response content",
+    style: "table",
+    position: { x: 8, y: 8, width: 4, height: 8 },
+    query: {
+      granularity: 10,
+      breakdowns: ["http.url"],
+      calculations: [{ column: "http.response_content_length", op: "AVG" }],
+      filters: [
+        { column: "http.response_content_length", op: "exists" },
+        { column: "name", op: "=", value: "resourceFetch" },
+      ],
+      orders: [
+        {
+          column: "http.response_content_length",
+          op: "AVG",
+          order: "descending",
+        },
+      ],
+      limit: 100,
+      time_range: 7200,
+    },
+  },
+  {
+    key: "slowest-endpoints",
+    label: "Slowest Requests by Endpoint",
+    description:
+      "The slowest endpoints based on the 75th percentile of request durations",
+    style: "table",
+    position: { x: 0, y: 16, width: 4, height: 8 },
+    query: {
+      breakdowns: ["name", "http.url"],
+      calculations: [{ column: "duration_ms", op: "P75" }],
+      filters: [
+        { column: "http.url", op: "exists" },
+        {
+          column: "name",
+          op: "in",
+          value: ["HTTP GET", "HTTP POST", "GET", "POST"],
+        },
+      ],
+      orders: [{ column: "duration_ms", op: "P75", order: "descending" }],
+      limit: 100,
+      time_range: 7200,
+    },
+  },
+  {
+    key: "top-landing-pages",
+    label: "Top Landing Pages by Session Count",
+    description: "The most visited landing pages ranked by session count",
+    style: "table",
+    position: { x: 4, y: 16, width: 4, height: 8 },
+    query: {
+      granularity: 10,
+      breakdowns: ["entry_page.path"],
+      calculations: [{ op: "COUNT" }],
+      filters: [
+        { column: "entry_page.path", op: "exists" },
+        { column: "name", op: "=", value: "documentLoad" },
+      ],
+      orders: [{ op: "COUNT", order: "descending" }],
+      limit: 100,
+      time_range: 7200,
+    },
+  },
+  {
+    key: "busiest-pages",
+    label: "Pages With the Most Events",
+    description:
+      "Pages with the highest number of events, highlighting the most active pages",
+    style: "table",
+    position: { x: 8, y: 16, width: 4, height: 8 },
+    query: {
+      granularity: 10,
+      breakdowns: ["page.route"],
+      calculations: [{ op: "COUNT" }],
+      filters: [{ column: "page.route", op: "exists" }],
+      orders: [{ op: "COUNT", order: "descending" }],
+      limit: 100,
+      time_range: 7200,
+    },
+  },
+];
+
+// Honeycomb lays boards out on a 12 column grid. The vitals sit three to a row
+// under their heading, then the ported overview section starts below them, so
+// each section reads as its own block.
+const GRID_COLUMNS = 12;
+const HEADING_HEIGHT = 2;
+const VITAL_WIDTH = 4;
+const VITAL_HEIGHT = 4;
+const VITALS_PER_ROW = GRID_COLUMNS / VITAL_WIDTH;
+const VITALS_ORIGIN_Y = HEADING_HEIGHT;
+const OVERVIEW_HEADING_Y =
+  VITALS_ORIGIN_Y + Math.ceil(vitals.length / VITALS_PER_ROW) * VITAL_HEIGHT;
+const OVERVIEW_ORIGIN_Y = OVERVIEW_HEADING_Y + HEADING_HEIGHT;
+
 // Build a curated RUM board in one environment, authenticated with that
 // environment's v1 Configuration Key. `slug` (prod/local) keeps resource names
-// unique across the two boards. A compact hand-built board is preferred over
-// importing the sprawling template board (see issue #59): the template's panels
-// reference many UI-managed queries that `pulumi import` would leave unmanaged.
+// unique across the two boards.
 //
 // The name deliberately differs from the hand-made `Real User Monitoring (RUM)`
 // template board that already exists in both environments, so the two coexist
@@ -135,44 +326,106 @@ function rumBoard(
   });
   const providerOpts = { provider };
 
-  const panels = vitals.map(v => {
+  // A query panel and the two resources behind it. `name` is the Pulumi resource
+  // name and must stay stable: the vitals panels were created as
+  // `rum-<slug>-<key>` before the overview section existed, and changing those
+  // names would replace live queries.
+  const queryPanel = (
+    name: string,
+    queryJson: object,
+    label: string,
+    caption: string,
+    style: string,
+    position: { x: number; y: number; width: number; height: number }
+  ) => {
     const query = new honeycombio.Query(
-      `rum-${slug}-${v.key}`,
-      {
-        dataset: datasetName,
-        queryJson: JSON.stringify({
-          calculations: [{ op: "P75", column: `${v.key}.value` }],
-          time_range: 604800,
-        }),
-      },
+      name,
+      { dataset: datasetName, queryJson: JSON.stringify(queryJson) },
       providerOpts
     );
     const annotation = new honeycombio.QueryAnnotation(
-      `rum-${slug}-${v.key}`,
+      name,
       {
         dataset: datasetName,
         queryId: query.id,
-        name: v.label,
-        description: v.description,
+        name: label,
+        description: caption,
       },
       providerOpts
     );
     return {
       type: "query",
+      position: {
+        xCoordinate: position.x,
+        yCoordinate: position.y,
+        width: position.width,
+        height: position.height,
+      },
       queryPanels: [
         {
           queryId: query.id,
           queryAnnotationId: annotation.id,
-          queryStyle: "graph",
+          queryStyle: style,
         },
       ],
     };
+  };
+
+  // Full-width Markdown panel that titles a section.
+  const heading = (yCoordinate: number, content: string) => ({
+    type: "text",
+    position: {
+      xCoordinate: 0,
+      yCoordinate,
+      width: GRID_COLUMNS,
+      height: HEADING_HEIGHT,
+    },
+    textPanels: [{ content }],
   });
+
+  const panels = [
+    heading(
+      0,
+      "## Core Web Vitals\n\np75 over the last 7 days, the window Google reports Core Web Vitals over."
+    ),
+    ...vitals.map((v, i) =>
+      queryPanel(
+        `rum-${slug}-${v.key}`,
+        {
+          calculations: [{ op: "P75", column: `${v.key}.value` }],
+          time_range: 604800,
+        },
+        v.label,
+        v.description,
+        "graph",
+        {
+          x: (i % VITALS_PER_ROW) * VITAL_WIDTH,
+          y: VITALS_ORIGIN_Y + Math.floor(i / VITALS_PER_ROW) * VITAL_HEIGHT,
+          width: VITAL_WIDTH,
+          height: VITAL_HEIGHT,
+        }
+      )
+    ),
+    heading(
+      OVERVIEW_HEADING_Y,
+      "## RUM overview\n\nPorted from the hand-made `Real User Monitoring (RUM)` board, over a two hour window."
+    ),
+    ...overview.map(o =>
+      queryPanel(
+        `rum-${slug}-ov-${o.key}`,
+        o.query,
+        o.label,
+        o.description,
+        o.style,
+        { ...o.position, y: OVERVIEW_ORIGIN_Y + o.position.y }
+      )
+    ),
+  ];
 
   const board = new honeycombio.FlexibleBoard(
     `rum-${slug}-board`,
     {
-      name: "Core Web Vitals (Pulumi-managed)",
+      name: "Real User Monitoring (Pulumi-managed)",
       description,
       panels,
     },
@@ -199,7 +452,7 @@ if (manageProdBoard) {
   prodBoardId = rumBoard(
     "prod",
     requireConfigKey("HONEYCOMB_CONFIG_KEY", "manageProdBoard"),
-    "Core Web Vitals for tollmanz.com browser RUM (p75 over the last 7 days). Managed by infra/honeycomb (Pulumi)."
+    "Core Web Vitals and a RUM overview for tollmanz.com browser RUM. Managed by infra/honeycomb (Pulumi)."
   );
 }
 
@@ -208,7 +461,7 @@ if (manageLocalBoard) {
   localBoardId = rumBoard(
     "local",
     requireConfigKey("HONEYCOMB_LOCAL_CONFIG_KEY", "manageLocalBoard"),
-    "Core Web Vitals for tollmanz.com browser RUM, local testing environment (p75 over the last 7 days). Managed by infra/honeycomb (Pulumi)."
+    "Core Web Vitals and a RUM overview for tollmanz.com browser RUM, local testing environment. Managed by infra/honeycomb (Pulumi)."
   );
 }
 

--- a/infra/honeycomb/index.ts
+++ b/infra/honeycomb/index.ts
@@ -119,6 +119,12 @@ const vitals = [
 // unique across the two boards. A compact hand-built board is preferred over
 // importing the sprawling template board (see issue #59): the template's panels
 // reference many UI-managed queries that `pulumi import` would leave unmanaged.
+//
+// The name deliberately differs from the hand-made `Real User Monitoring (RUM)`
+// template board that already exists in both environments, so the two coexist
+// unambiguously in the boards list. Honeycomb keys boards by ID and permits
+// duplicate names, so reusing that name would silently produce two similar-
+// looking boards in the same environment.
 function rumBoard(
   slug: string,
   configKey: string,
@@ -166,7 +172,7 @@ function rumBoard(
   const board = new honeycombio.FlexibleBoard(
     `rum-${slug}-board`,
     {
-      name: "Real User Monitoring (RUM)",
+      name: "Core Web Vitals (Pulumi-managed)",
       description,
       panels,
     },

--- a/infra/honeycomb/index.ts
+++ b/infra/honeycomb/index.ts
@@ -234,23 +234,22 @@ const overview = [
     },
   },
   {
+    // Retargeted from the template's version, which filtered `name` to fetch and
+    // XHR span names (`HTTP GET` and friends). This site issues no fetch or XHR
+    // calls, and the RUM exporter's own request is excluded from instrumentation
+    // (see assets/rum/index.js), so that filter matched nothing and the panel was
+    // always empty. The navigation request is a `documentFetch` span, which is
+    // what "slowest request" means here.
     key: "slowest-endpoints",
-    label: "Slowest Requests by Endpoint",
+    label: "Slowest Pages by Document Fetch",
     description:
-      "The slowest endpoints based on the 75th percentile of request durations",
+      "Routes ranked by the 75th percentile of their navigation request duration",
     style: "table",
     position: { x: 0, y: 16, width: 4, height: 8 },
     query: {
-      breakdowns: ["name", "http.url"],
+      breakdowns: ["page.route"],
       calculations: [{ column: "duration_ms", op: "P75" }],
-      filters: [
-        { column: "http.url", op: "exists" },
-        {
-          column: "name",
-          op: "in",
-          value: ["HTTP GET", "HTTP POST", "GET", "POST"],
-        },
-      ],
+      filters: [{ column: "name", op: "=", value: "documentFetch" }],
       orders: [{ column: "duration_ms", op: "P75", order: "descending" }],
       limit: 100,
       time_range: 7200,
@@ -258,8 +257,15 @@ const overview = [
   },
   {
     key: "top-landing-pages",
-    label: "Top Landing Pages by Session Count",
-    description: "The most visited landing pages ranked by session count",
+    // Counting document loads, not visits. The Honeycomb web SDK mints its
+    // session id once per document (`sessionId` is module scoped with no
+    // storage), so on this multi-page site every navigation starts a new session
+    // and `entry_page.path` is just the path that was loaded. COUNT_DISTINCT over
+    // `session.id` would return the same number under a name that implies
+    // otherwise, so the label says page load instead.
+    label: "Top Landing Pages by Page Load",
+    description:
+      "Landing pages ranked by document load count. Each navigation is its own session here, so this counts page loads rather than distinct visits",
     style: "table",
     position: { x: 4, y: 16, width: 4, height: 8 },
     query: {


### PR DESCRIPTION
Brings the Honeycomb RUM board under Pulumi management in `infra/honeycomb` (issue #59), so the dashboard is code like the environments and ingest keys already are.

## What it manages

One `Real User Monitoring (RUM)` board per environment, in two sections against the `tollmanz-com-web` dataset:

| Section         | Panels | Window                  | Content                                |
| --------------- | ------ | ----------------------- | -------------------------------------- |
| Core Web Vitals | 5      | 7 day p75               | LCP, INP, CLS, FCP, TTFB               |
| RUM overview    | 9      | 2 hour, 10s granularity | Ported from Honeycomb's template board |

A full-width Markdown text panel titles each section, and every panel carries an explicit position on Honeycomb's 12 column grid, so the layout is deterministic rather than whatever order the API returns. Core Web Vitals sits on top, three panels to a row, and the overview section follows below keeping the template board's own arrangement.

The overview queries are reproduced as managed `Query` and `QueryAnnotation` resources rather than referenced by ID, so the board depends on no UI-owned resource. That is also why it is hand-built rather than a `pulumi import` of the template board, whose panels pointed at queries import would have left unmanaged.

Seven of the nine overview queries are reproduced verbatim. Two were corrected, because the template was written for a generic web app rather than this one:

* `Slowest Pages by Document Fetch` was `Slowest Requests by Endpoint`, filtering `name` to fetch and XHR spans (`HTTP GET` and friends). This site makes no fetch or XHR calls at all, and the RUM exporter's own request is excluded from instrumentation, so nothing ever matched and the panel was permanently empty. It now measures `documentFetch`, the navigation request, by `page.route`
* `Top Landing Pages by Page Load` was `Top Landing Pages by Session Count`. The Honeycomb web SDK mints a session id once per document with no persistence, so every navigation on this multi-page site starts a new session. The query counts document loads, and `COUNT_DISTINCT(session.id)` would return the same figure, so only the label was wrong

## How the v1 tier is authenticated

Boards, queries, and query annotations are v1 API resources. They need a v1 Configuration Key scoped to a single environment, not the v2 Management Key the rest of this project uses, so each board runs through a second `honeycombio.Provider`.

Minting a configuration key from the Management Key fails on this plan (`access to this API is disabled: Error Creating Honeycomb API Key`), so each key is created by hand in the Honeycomb UI and supplied out of band via `HONEYCOMB_CONFIG_KEY` and `HONEYCOMB_LOCAL_CONFIG_KEY`. Both are set in the repo-root `.env` and as repository secrets.

Enablement is gated on the committed `manageProdBoard` and `manageLocalBoard` flags rather than on env-var presence, so board state is deterministic across apply contexts. With one shared stack, keying on the env var would let a local apply create a board and a CI apply without the key delete it.

## A schema fix outside Pulumi

Honeycomb infers column types from the first value seen, coerces later values to that type, and substitutes `0` when coercion is not possible, so a numeric metric on the wrong type is corrupted at ingest rather than merely displayed oddly.

Prod had `cls.value` as `integer`. CLS is fractional with thresholds at 0.1 and 0.25, so every score was being truncated toward zero and `P75(cls.value)` was meaningless. The column was corrected to `float` with `PUT /1/columns`, matching local. The type governs later writes only, so prod CLS data written before the fix stays coerced. `lcp.value`, `fcp.value`, and `inp.value` are still `integer`, which is insignificant for whole-millisecond timings.

Columns are deliberately not declared as Pulumi resources, since a declared type would try to mutate whatever ingest already created. The README documents how to check the types before trusting a new environment's board.

## Current state

* local is applied and verified: board `2HmW5tfeQZQ`, 16 panels
* prod has `manageProdBoard` committed as true but is deliberately not applied locally, so the honeycomb workflow creates it on merge and exercises the CI path end to end. Prod has no board until then

Honeycomb's template had created a hand-made 9-panel `Real User Monitoring (RUM)` board in both environments (`uymoPQWt5Hh` in prod, `nUnmjid2hYb` in local). Both were deleted after confirming they were identical to each other and fully reproduced in the overview section, and after snapshotting each one with its query and annotation definitions. With the name free, the managed board took it and the `(Pulumi-managed)` suffix came off.

## Verification

* the 7 verbatim panels were compared field by field against the source board, and annotation name, description, `query_style`, and normalized query JSON all match
* the local apply is idempotent, with a follow-up preview reporting `35 unchanged`
* prod preview reports `+30 to create`, confined to `rum-prod-*`, with local untouched
* all columns the prod board queries were verified present in `tollmanz-com`

## Notes for review

* a saved query cannot be created against a column that does not exist yet. `inp.value` is the one that bites, since INP is only emitted after a real user interaction, so a fresh environment can carry every other vital and still be missing INP. The README documents seeding it with a single event
* changing a query's `query_json` replaces the resource, because the provider marks that attribute `RequiresReplace` and Honeycomb saved queries are immutable. The provider's delete is a deliberate no-op, so a replacement orphans the old saved query rather than failing
* the "Run Queries" permission is not required on a Configuration Key. The board tier only creates saved query specs and never executes them, and that permission is plan-gated

Closes #59
