### PR TITLE
feat: enhance collection config with metadata and validation

### DIFF
--- a/collections/index.js
+++ b/collections/index.js
@@ -1,0 +1,46 @@
+import { validateCollection } from "./validate.js";
+
+const POSTS_GLOB = "src/posts/*.md";
+const PAGES_GLOB = "src/pages/*.md";
+
+// Run a collection builder, degrading to `fallback` with a clear error rather
+// than crashing the whole build when something unexpected throws.
+function buildCollection(label, fallback, build) {
+  try {
+    return build();
+  } catch (error) {
+    console.error(`[collections] Failed to build "${label}": ${error.message}`);
+    return fallback;
+  }
+}
+
+// Register all content collections onto the Eleventy config. Scope is metadata
+// and validation only: nothing here creates new URLs or surfaces internal
+// front-matter fields. See docs/collections.md.
+export default function registerCollections(eleventyConfig) {
+  eleventyConfig.addCollection("posts", collectionApi =>
+    buildCollection("posts", [], () =>
+      validateCollection(
+        collectionApi
+          .getFilteredByGlob(POSTS_GLOB)
+          .sort((a, b) => b.date - a.date),
+        "posts"
+      )
+    )
+  );
+
+  eleventyConfig.addCollection("pages", collectionApi =>
+    buildCollection("pages", [], () =>
+      validateCollection(collectionApi.getFilteredByGlob(PAGES_GLOB), "pages")
+    )
+  );
+
+  // Lightweight metadata templates can consume without re-counting collections,
+  // e.g. {{ collections.collectionMeta.posts }}. Counts only.
+  eleventyConfig.addCollection("collectionMeta", collectionApi =>
+    buildCollection("collectionMeta", { posts: 0, pages: 0 }, () => ({
+      posts: collectionApi.getFilteredByGlob(POSTS_GLOB).length,
+      pages: collectionApi.getFilteredByGlob(PAGES_GLOB).length,
+    }))
+  );
+}

--- a/collections/validate.js
+++ b/collections/validate.js
@@ -1,0 +1,51 @@
+// Front-matter fields every content item needs. Templates and feeds render
+// title, url, and date (index list, sitemap, RSS), so a missing value ships
+// broken output rather than failing the build.
+export const REQUIRED_FIELDS = ["title", "date"];
+
+// Return a list of human-readable problems with the given collection items,
+// each naming the offending file. Pure: the caller decides how to report.
+export function collectionProblems(items, label) {
+  const problems = [];
+
+  if (!Array.isArray(items)) {
+    return problems;
+  }
+
+  for (const item of items) {
+    const inputPath = item?.inputPath ?? "(unknown file)";
+    const data = item?.data ?? {};
+
+    for (const field of REQUIRED_FIELDS) {
+      const value = data[field];
+      if (value === undefined || value === null || value === "") {
+        problems.push(
+          `${label}: "${inputPath}" is missing required front-matter ` +
+            `field "${field}"`
+        );
+      }
+    }
+
+    const { date } = data;
+    if (
+      date !== undefined &&
+      date !== null &&
+      date !== "" &&
+      Number.isNaN(new Date(date).getTime())
+    ) {
+      problems.push(`${label}: "${inputPath}" has an invalid date value`);
+    }
+  }
+
+  return problems;
+}
+
+// Warn loudly and name the file instead of throwing: Eleventy already halts on
+// truly fatal input, and a single malformed draft should not block the whole
+// build. Returns the items unchanged so callers can validate inline.
+export function validateCollection(items, label) {
+  for (const problem of collectionProblems(items, label)) {
+    console.warn(`[collections] ${problem}`);
+  }
+  return items;
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ Reference documentation for tollmanz.com.
   templates, and how build metadata and site validation work
 - [filters.md](filters.md): the `filters/` Eleventy custom filters, what each
   does, and how to add one
+- [collections.md](collections.md): the `collections/` Eleventy collections,
+  what each exposes to templates, and their front-matter validation rules
 - [edge-caching.md](edge-caching.md): how the site caches, compresses, and serves
   content at the Fastly edge in front of GitHub Pages, and why
 - [edge-verification.md](edge-verification.md): the `tests/edge/` suite that

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -1,0 +1,42 @@
+# Collections
+
+Eleventy content collections live in `collections/`. `collections/index.js`
+exports `registerCollections(eleventyConfig)`, which `eleventy.config.js` calls
+to register them all; `collections/validate.js` holds the front-matter checks as
+plain, testable functions.
+
+| Collection       | Source           | Shape                             |
+| ---------------- | ---------------- | --------------------------------- |
+| `posts`          | `src/posts/*.md` | Items sorted newest first by date |
+| `pages`          | `src/pages/*.md` | Items in default (file) order     |
+| `collectionMeta` | both globs       | `{ posts, pages }` item counts    |
+
+`collectionMeta` exists for templates that need a count without re-globbing,
+e.g. `{{ collections.collectionMeta.posts }}`.
+
+## Validation
+
+Each item in `posts` and `pages` is checked for the required front-matter
+fields `title` and `date`. A missing or empty value emits a `console.warn`
+naming the file; an unparseable `date` warns as well. Validation warns rather
+than throws so a single malformed draft cannot block the build. Eleventy still
+fails hard on genuinely fatal input.
+
+Collection construction is wrapped in `try`/`catch`: on an unexpected error the
+collection degrades to an empty value with a `console.error` instead of crashing
+the build.
+
+## Scope
+
+Collections carry metadata and validation only. They do not create tag or
+category archive pages or any new URLs. The `categories` front-matter field on
+posts stays internal and is not surfaced publicly.
+
+## Adding a collection
+
+1. Register it in `collections/index.js`, wrapped in `buildCollection` so a
+   failure degrades instead of crashing the build
+2. Extend `collections/validate.js` if it needs new front-matter checks
+3. Add unit tests under `tests/unit/`
+
+Run the collection tests with `npm run test:unit`.

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -6,6 +6,7 @@ import { eleventyImageTransformPlugin } from "@11ty/eleventy-img";
 import CleanCSS from "clean-css";
 import markdownIt from "markdown-it";
 import registerFilters from "./filters/index.js";
+import registerCollections from "./collections/index.js";
 
 export default function (eleventyConfig) {
   // Add plugins
@@ -106,18 +107,10 @@ export default function (eleventyConfig) {
     eleventyConfig.addPassthroughCopy({ "build/js": "js" });
   }
 
-  // Create collections
-  eleventyConfig.addCollection("posts", function (collectionApi) {
-    return collectionApi
-      .getFilteredByGlob("src/posts/*.md")
-      .sort(function (a, b) {
-        return b.date - a.date;
-      });
-  });
-
-  eleventyConfig.addCollection("pages", function (collectionApi) {
-    return collectionApi.getFilteredByGlob("src/pages/*.md");
-  });
+  // Content collections (posts, pages, collectionMeta), extracted into the
+  // collections/ directory with their front-matter validation. See
+  // docs/collections.md.
+  registerCollections(eleventyConfig);
 
   // Custom filters (dateDisplay, head, hasCodeBlocks), extracted into the
   // filters/ directory and grouped by concern. See docs/filters.md.

--- a/tests/unit/collections.test.js
+++ b/tests/unit/collections.test.js
@@ -1,0 +1,185 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import registerCollections from "../../collections/index.js";
+import { collectionProblems } from "../../collections/validate.js";
+
+function item(inputPath, data) {
+  return { inputPath, data };
+}
+
+// Minimal stand-ins for the Eleventy config and collection API surfaces the
+// module touches, so registration and collection callbacks run for real.
+function fakeConfig() {
+  const collections = {};
+  return {
+    collections,
+    addCollection(name, callback) {
+      collections[name] = callback;
+    },
+  };
+}
+
+function fakeApi(byGlob) {
+  return {
+    getFilteredByGlob(glob) {
+      const items = byGlob[glob];
+      if (!items) {
+        throw new Error(`unexpected glob: ${glob}`);
+      }
+      return items.slice();
+    },
+  };
+}
+
+const POSTS = "src/posts/*.md";
+const PAGES = "src/pages/*.md";
+
+test("collectionProblems reports nothing for well-formed items", () => {
+  const items = [
+    item("src/posts/a.md", { title: "A", date: new Date("2026-01-01") }),
+  ];
+  assert.deepEqual(collectionProblems(items, "posts"), []);
+});
+
+test("collectionProblems names the file and the missing field", () => {
+  const problems = collectionProblems(
+    [item("src/posts/a.md", { date: new Date("2026-01-01") })],
+    "posts"
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /posts: "src\/posts\/a\.md"/);
+  assert.match(problems[0], /field "title"/);
+});
+
+test("collectionProblems treats null and empty string as missing", () => {
+  const problems = collectionProblems(
+    [item("src/pages/a.md", { title: "", date: null })],
+    "pages"
+  );
+  assert.equal(problems.length, 2);
+});
+
+test("collectionProblems reports one problem per missing field", () => {
+  const problems = collectionProblems([item("src/posts/a.md", {})], "posts");
+  assert.deepEqual(
+    problems.map(p => p.match(/field "(\w+)"/)[1]),
+    ["title", "date"]
+  );
+});
+
+test("collectionProblems flags an unparseable date", () => {
+  const problems = collectionProblems(
+    [item("src/posts/a.md", { title: "A", date: "not a date" })],
+    "posts"
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /invalid date value/);
+});
+
+test("collectionProblems does not double-report a missing date as invalid", () => {
+  const problems = collectionProblems(
+    [item("src/posts/a.md", { title: "A" })],
+    "posts"
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /field "date"/);
+});
+
+test("collectionProblems accepts a date string Date can parse", () => {
+  const problems = collectionProblems(
+    [item("src/posts/a.md", { title: "A", date: "2026-01-01" })],
+    "posts"
+  );
+  assert.deepEqual(problems, []);
+});
+
+test("collectionProblems tolerates items without inputPath or data", () => {
+  const problems = collectionProblems([{}], "posts");
+  assert.equal(problems.length, 2);
+  for (const problem of problems) {
+    assert.match(problem, /\(unknown file\)/);
+  }
+});
+
+test("collectionProblems returns an empty list for non-array input", () => {
+  assert.deepEqual(collectionProblems(null, "posts"), []);
+  assert.deepEqual(collectionProblems(undefined, "posts"), []);
+});
+
+test("registerCollections registers posts, pages, and collectionMeta", () => {
+  const config = fakeConfig();
+  registerCollections(config);
+  assert.deepEqual(Object.keys(config.collections).sort(), [
+    "collectionMeta",
+    "pages",
+    "posts",
+  ]);
+});
+
+test("posts is sorted newest first", () => {
+  const config = fakeConfig();
+  registerCollections(config);
+  const api = fakeApi({
+    [POSTS]: [
+      { inputPath: "src/posts/old.md", date: new Date("2020-01-01"), data: {} },
+      { inputPath: "src/posts/new.md", date: new Date("2026-01-01"), data: {} },
+    ],
+  });
+  const posts = config.collections.posts(api);
+  assert.deepEqual(
+    posts.map(p => p.inputPath),
+    ["src/posts/new.md", "src/posts/old.md"]
+  );
+});
+
+test("pages keeps the glob order", () => {
+  const config = fakeConfig();
+  registerCollections(config);
+  const api = fakeApi({
+    [PAGES]: [item("src/pages/b.md", {}), item("src/pages/a.md", {})],
+  });
+  assert.deepEqual(
+    config.collections.pages(api).map(p => p.inputPath),
+    ["src/pages/b.md", "src/pages/a.md"]
+  );
+});
+
+test("collectionMeta exposes item counts", () => {
+  const config = fakeConfig();
+  registerCollections(config);
+  const api = fakeApi({
+    [POSTS]: [item("src/posts/a.md", {}), item("src/posts/b.md", {})],
+    [PAGES]: [item("src/pages/a.md", {})],
+  });
+  assert.deepEqual(config.collections.collectionMeta(api), {
+    posts: 2,
+    pages: 1,
+  });
+});
+
+test("a validation warning does not drop the item from the collection", t => {
+  t.mock.method(console, "warn", () => {});
+  const config = fakeConfig();
+  registerCollections(config);
+  const api = fakeApi({ [PAGES]: [item("src/pages/a.md", {})] });
+  assert.equal(config.collections.pages(api).length, 1);
+  assert.equal(console.warn.mock.callCount(), 2);
+});
+
+test("a throwing collection degrades to empty instead of crashing", t => {
+  t.mock.method(console, "error", () => {});
+  const config = fakeConfig();
+  registerCollections(config);
+  const api = {
+    getFilteredByGlob() {
+      throw new Error("boom");
+    },
+  };
+  assert.deepEqual(config.collections.posts(api), []);
+  assert.deepEqual(config.collections.pages(api), []);
+  assert.deepEqual(config.collections.collectionMeta(api), {
+    posts: 0,
+    pages: 0,
+  });
+  assert.equal(console.error.mock.callCount(), 3);
+});


### PR DESCRIPTION
## Summary

Enhances the `posts` and `pages` collections in `eleventy.config.js` with
validation and lightweight metadata. Scope is metadata and validation only:
no tag/category archive pages, no new URLs, and the internal `categories`
front-matter field stays internal.

- Validate each `posts`/`pages` item for required front-matter fields
  (`title`, `date`), emitting a `console.warn` that names the offending file
  when a value is missing, empty, or an unparseable date. Warnings do not
  throw, so a single malformed draft cannot block the build; Eleventy still
  fails hard on genuinely fatal input.
- Wrap collection construction in `try`/`catch` so an unexpected error
  degrades the collection to empty with a `console.error` instead of crashing
  the build.
- Add a `collectionMeta` collection exposing `{ posts, pages }` item counts
  for templates to consume (e.g. `{{ collections.collectionMeta.posts }}`).
  Counts only; no new URLs.
- Document the collection configuration in `docs/collections.md` and link it
  from `docs/README.md`.

## Verification

- `npm run build` succeeds with no validation warnings (all current content
  has `title` and `date`); existing templates (index list, sitemap, RSS,
  footer) render unchanged.
- `npm run lint` and `npm run prettier:check` pass.

## Coordination

Issues #24, #29, and #33 also edit `eleventy.config.js` on sibling branches.
This diff is intentionally minimal and confined to the collection block to
ease rebasing.

Fixes #28