### PR TITLE
refactor: extract and gate eleventy minify transforms

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ Reference documentation for tollmanz.com.
   does, and how to add one
 - [collections.md](collections.md): the `collections/` Eleventy collections,
   what each exposes to templates, and their front-matter validation rules
+- [transforms.md](transforms.md): how the `transforms/` Eleventy output
+  transforms are organized, gated to production, and handle errors
 - [edge-caching.md](edge-caching.md): how the site caches, compresses, and serves
   content at the Fastly edge in front of GitHub Pages, and why
 - [edge-verification.md](edge-verification.md): the `tests/edge/` suite that

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -1,0 +1,36 @@
+# Transforms
+
+Eleventy output transforms live in `transforms/`, one ESM module per transform.
+`transforms/index.js` exports `registerTransforms(eleventyConfig)`, which
+`eleventy.config.js` calls to register them all.
+
+| Transform | Module                  | Purpose                                           |
+| --------- | ----------------------- | ------------------------------------------------- |
+| `htmlmin` | `transforms/htmlmin.js` | Minify `.html` output with `html-minifier-terser` |
+| `cssmin`  | `transforms/cssmin.js`  | Minify `.css` output with `clean-css`             |
+
+Each transform inspects `this.page.outputPath` and returns non-matching output
+unchanged, so ordering against other transforms does not matter.
+
+## Conditional application
+
+Minification runs for production builds only. `registerTransforms` registers
+nothing unless `process.env.ELEVENTY_RUN_MODE === "build"`, which Eleventy sets
+to `build` for `npm run build` and to `serve`/`watch` for `npm run dev`.
+Skipping minification during dev keeps rebuilds fast and output readable.
+
+## Error handling
+
+Each transform guards its work in try/catch. On failure it logs a
+`console.warn` and returns the original, unminified content, so one bad page or
+stylesheet degrades output rather than breaking the build. `cssmin` also treats
+a non-empty `result.errors` from clean-css as a failure and falls back the same
+way.
+
+## Adding a transform
+
+1. Add a module under `transforms/` that exports the transform function
+2. Register it in `transforms/index.js`
+3. Add unit tests under `tests/unit/`
+
+Run the transform tests with `npm run test:unit`.

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,12 +1,11 @@
 import fs from "node:fs";
-import { minify } from "html-minifier-terser";
 import syntaxHighlight from "@11ty/eleventy-plugin-syntaxhighlight";
 import pluginRss from "@11ty/eleventy-plugin-rss";
 import { eleventyImageTransformPlugin } from "@11ty/eleventy-img";
-import CleanCSS from "clean-css";
 import markdownIt from "markdown-it";
 import registerFilters from "./filters/index.js";
 import registerCollections from "./collections/index.js";
+import registerTransforms from "./transforms/index.js";
 
 export default function (eleventyConfig) {
   // Add plugins
@@ -38,60 +37,10 @@ export default function (eleventyConfig) {
     },
   });
 
-  // HTML minification transform
-  eleventyConfig.addTransform("htmlmin", async function (content) {
-    if ((this.page.outputPath || "").endsWith(".html")) {
-      let minified = await minify(content, {
-        collapseWhitespace: true,
-        minifyJS: true,
-        minifyCSS: true,
-        removeAttributeQuotes: true,
-        removeComments: true,
-      });
-      return minified;
-    }
-    // If not an HTML output, return content as-is
-    return content;
-  });
-
-  // CSS minification transform
-  eleventyConfig.addTransform("cssmin", function (content) {
-    if ((this.page.outputPath || "").endsWith(".css")) {
-      const cleanCSS = new CleanCSS({
-        level: 2,
-        returnPromise: false,
-      });
-
-      try {
-        const result = cleanCSS.minify(content);
-
-        if (result.errors.length > 0) {
-          console.error(
-            `CSS minification errors for ${this.page.outputPath}:`,
-            result.errors
-          );
-          return content;
-        } else {
-          if (result.warnings.length > 0) {
-            console.warn(
-              `CSS minification warnings for ${this.page.outputPath}:`,
-              result.warnings
-            );
-          }
-
-          return result.styles;
-        }
-      } catch (error) {
-        console.error(
-          `Error minifying CSS file ${this.page.outputPath}:`,
-          error.message
-        );
-        return content;
-      }
-    }
-    // If not a CSS output, return content as-is
-    return content;
-  });
+  // Minification transforms (see transforms/ and docs/transforms.md). Only run
+  // for production builds (`npm run build`), not the dev server: skipping
+  // minification in serve/watch keeps rebuilds fast and output readable.
+  registerTransforms(eleventyConfig);
 
   // Copy static assets
   eleventyConfig.addPassthroughCopy("src/fonts");

--- a/tests/unit/transforms.test.js
+++ b/tests/unit/transforms.test.js
@@ -1,0 +1,130 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import registerTransforms, { shouldMinify } from "../../transforms/index.js";
+import htmlmin from "../../transforms/htmlmin.js";
+import cssmin from "../../transforms/cssmin.js";
+
+// Minimal stand-in for the Eleventy config surface the module touches, so
+// registration runs for real.
+function fakeConfig() {
+  const transforms = {};
+  return {
+    transforms,
+    addTransform(name, callback) {
+      transforms[name] = callback;
+    },
+  };
+}
+
+// Transforms read this.page.outputPath to decide whether they apply.
+function page(outputPath) {
+  return { page: { outputPath } };
+}
+
+// Swallow the console.warn a fallback path emits, and hand back what it logged.
+function captureWarnings(run) {
+  const original = console.warn;
+  const warnings = [];
+  console.warn = (...args) => warnings.push(args);
+  try {
+    return { result: run(), warnings };
+  } finally {
+    console.warn = original;
+  }
+}
+
+test("shouldMinify is true only for the build run mode", () => {
+  assert.equal(shouldMinify({ ELEVENTY_RUN_MODE: "build" }), true);
+  assert.equal(shouldMinify({ ELEVENTY_RUN_MODE: "serve" }), false);
+  assert.equal(shouldMinify({ ELEVENTY_RUN_MODE: "watch" }), false);
+  assert.equal(shouldMinify({}), false);
+});
+
+test("registerTransforms registers both transforms for a production build", () => {
+  const previous = process.env.ELEVENTY_RUN_MODE;
+  process.env.ELEVENTY_RUN_MODE = "build";
+  try {
+    const config = fakeConfig();
+    registerTransforms(config);
+    assert.deepEqual(Object.keys(config.transforms).sort(), [
+      "cssmin",
+      "htmlmin",
+    ]);
+  } finally {
+    process.env.ELEVENTY_RUN_MODE = previous;
+  }
+});
+
+test("registerTransforms registers nothing for the dev server", () => {
+  const previous = process.env.ELEVENTY_RUN_MODE;
+  process.env.ELEVENTY_RUN_MODE = "serve";
+  try {
+    const config = fakeConfig();
+    registerTransforms(config);
+    assert.deepEqual(Object.keys(config.transforms), []);
+  } finally {
+    process.env.ELEVENTY_RUN_MODE = previous;
+  }
+});
+
+test("htmlmin minifies .html output", async () => {
+  const html = "<html>  <body>   <p>hi</p>  </body>  </html>";
+  const output = await htmlmin.call(page("public/index.html"), html);
+  assert.equal(output.includes("   "), false);
+  assert.match(output, /<p>hi<\/p>/);
+});
+
+test("htmlmin strips comments from .html output", async () => {
+  const output = await htmlmin.call(
+    page("public/index.html"),
+    "<p>hi</p><!-- gone -->"
+  );
+  assert.equal(output.includes("gone"), false);
+});
+
+test("htmlmin leaves non-HTML output untouched", async () => {
+  const content = "body {\n  color: red;\n}\n";
+  assert.equal(await htmlmin.call(page("public/style.css"), content), content);
+  assert.equal(await htmlmin.call(page(undefined), content), content);
+});
+
+test("htmlmin falls back to the original content when minify throws", async () => {
+  const original = console.warn;
+  const warnings = [];
+  console.warn = (...args) => warnings.push(args);
+  try {
+    // html-minifier-terser wants a string; a Buffer from an upstream transform
+    // throws inside minify rather than returning a result.
+    const content = Buffer.from("<p>hi</p>");
+    const output = await htmlmin.call(page("public/broken.html"), content);
+    assert.equal(output, content);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0][0], /public\/broken\.html/);
+  } finally {
+    console.warn = original;
+  }
+});
+
+test("cssmin minifies .css output", () => {
+  const output = cssmin.call(
+    page("public/style.css"),
+    "body {\n  color: #ff0000;\n}\n"
+  );
+  assert.equal(output, "body{color:red}");
+});
+
+test("cssmin leaves non-CSS output untouched", () => {
+  const content = "<p>hi</p>";
+  assert.equal(cssmin.call(page("public/index.html"), content), content);
+  assert.equal(cssmin.call(page(undefined), content), content);
+});
+
+test("cssmin falls back to the original content when clean-css reports errors", () => {
+  const content = '@import url("does-not-exist.css");\nbody{color:red}';
+  const { result, warnings } = captureWarnings(() =>
+    cssmin.call(page("public/style.css"), content)
+  );
+  assert.equal(result, content);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0][0], /public\/style\.css/);
+});

--- a/transforms/cssmin.js
+++ b/transforms/cssmin.js
@@ -1,0 +1,39 @@
+import CleanCSS from "clean-css";
+
+// Eleventy transform: minify .css output. clean-css reports failures via
+// result.errors as well as by throwing; both paths log a warning and fall back
+// to the original content so a single bad file never breaks the build.
+export default function cssmin(content) {
+  if (!(this.page.outputPath || "").endsWith(".css")) {
+    return content;
+  }
+
+  const cleanCSS = new CleanCSS({ level: 2, returnPromise: false });
+
+  try {
+    const result = cleanCSS.minify(content);
+
+    if (result.errors.length > 0) {
+      console.warn(
+        `CSS minification failed for ${this.page.outputPath}; serving unminified content:`,
+        result.errors
+      );
+      return content;
+    }
+
+    if (result.warnings.length > 0) {
+      console.warn(
+        `CSS minification warnings for ${this.page.outputPath}:`,
+        result.warnings
+      );
+    }
+
+    return result.styles;
+  } catch (error) {
+    console.warn(
+      `CSS minification failed for ${this.page.outputPath}; serving unminified content:`,
+      error.message
+    );
+    return content;
+  }
+}

--- a/transforms/htmlmin.js
+++ b/transforms/htmlmin.js
@@ -1,0 +1,29 @@
+import { minify } from "html-minifier-terser";
+
+// html-minifier-terser options. minifyJS/minifyCSS also compress inline
+// <script>/<style> blocks that templates emit.
+const MINIFY_OPTIONS = {
+  collapseWhitespace: true,
+  minifyJS: true,
+  minifyCSS: true,
+  removeAttributeQuotes: true,
+  removeComments: true,
+};
+
+// Eleventy transform: minify .html output. On failure, log a warning and fall
+// back to the original content so a single bad page never breaks the build.
+export default async function htmlmin(content) {
+  if (!(this.page.outputPath || "").endsWith(".html")) {
+    return content;
+  }
+
+  try {
+    return await minify(content, MINIFY_OPTIONS);
+  } catch (error) {
+    console.warn(
+      `HTML minification failed for ${this.page.outputPath}; serving unminified content:`,
+      error.message
+    );
+    return content;
+  }
+}

--- a/transforms/index.js
+++ b/transforms/index.js
@@ -1,0 +1,21 @@
+import htmlmin from "./htmlmin.js";
+import cssmin from "./cssmin.js";
+
+// Eleventy sets ELEVENTY_RUN_MODE to "build" for `eleventy`, and to "serve" or
+// "watch" for `eleventy --serve`. Minification only earns its cost on the
+// production build: skipping it in serve/watch keeps rebuilds fast and the
+// served output readable.
+export function shouldMinify(env = process.env) {
+  return env.ELEVENTY_RUN_MODE === "build";
+}
+
+// Register the output transforms onto the Eleventy config. One transform per
+// sibling module: HTML (htmlmin.js) and CSS (cssmin.js). See docs/transforms.md.
+export default function registerTransforms(eleventyConfig) {
+  if (!shouldMinify()) {
+    return;
+  }
+
+  eleventyConfig.addTransform("htmlmin", htmlmin);
+  eleventyConfig.addTransform("cssmin", cssmin);
+}


### PR DESCRIPTION
## Summary

Extracts the inline `htmlmin` and `cssmin` transforms out of `eleventy.config.js` into a `transforms/` directory, gates minification to production builds, and unifies error handling. Layout matches the existing `filters/` and `collections/` modules on main.

- `transforms/htmlmin.js` and `transforms/cssmin.js`: one transform per module
- `transforms/index.js` exports `registerTransforms(eleventyConfig)`, mirroring `registerFilters` and `registerCollections`
- Minification registers only when `process.env.ELEVENTY_RUN_MODE === "build"` (i.e. `npm run build`). The dev server (`npm run dev`, run mode `serve`/`watch`) skips it, so rebuilds stay fast and output stays readable
- Both transforms try/catch, log a clear `console.warn` on failure, and fall back to the original unminified content. `htmlmin` previously had no try/catch; `cssmin` now uses `console.warn` consistently for its error path
- `tests/unit/transforms.test.js` covers the run-mode gate, the output-path guards, minification, and both fallback paths
- New `docs/transforms.md` documents the organization, the production gate, and the error-handling contract; linked from `docs/README.md`

## Verification

- `npm run build`: HTML and CSS output under `public/` is minified
- `npm run dev`: HTML and CSS output is unminified
- `npm run test:unit`: 42 tests pass
- `npm run format:check`: passes

Fixes #24