### PR TITLE
feat: add build metadata and site data validation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 Reference documentation for tollmanz.com.
 
+- [data.md](data.md): the `src/_data/` global data files, what each exposes to
+  templates, and how build metadata and site validation work
 - [edge-caching.md](edge-caching.md): how the site caches, compresses, and serves
   content at the Fastly edge in front of GitHub Pages, and why
 - [edge-verification.md](edge-verification.md): the `tests/edge/` suite that

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,61 @@
+# Global data
+
+Eleventy loads every file in `src/_data/` as global data, keyed by filename, and
+exposes it to all templates through the [data
+cascade](https://www.11ty.dev/docs/data-cascade/). Each file owns one purpose so
+the data a template needs is easy to find and hard to break.
+
+## Files
+
+| File        | Global   | Purpose                                                          |
+| ----------- | -------- | ---------------------------------------------------------------- |
+| `site.js`   | `site`   | Static site identity: title, description, URL, author            |
+| `assets.js` | `assets` | Content-hashed CSS URLs (single source of truth for `<link>`s)   |
+| `rum.js`    | `rum`    | Real user monitoring toggle and bundle URL, driven by `RUM_MODE` |
+| `build.js`  | `build`  | Build timestamp, version, commit, and environment                |
+
+Data files are JavaScript (ESM) rather than JSON so they can compute values at
+build time: `assets.js` hashes files, `rum.js` finds the built bundle, `build.js`
+reads git and the environment, and `site.js` validates its own fields.
+
+## `site`
+
+Static identity used across `head.njk`, `footer.njk`, `feed.njk`, `sitemap.njk`,
+and `robots.njk`.
+
+| Key               | Type   | Notes                                    |
+| ----------------- | ------ | ---------------------------------------- |
+| `title`           | string | Site name and title suffix               |
+| `description`     | string | Default meta/OG description              |
+| `url`             | string | Canonical origin, used to build abs URLs |
+| `author.name`     | string | Feed author, credited in metadata        |
+| `author.email`    | string | Feed author email                        |
+| `author.github`   | string | GitHub handle for the footer link        |
+| `author.mastodon` | string | Mastodon profile URL (`rel="me"`)        |
+
+`site.js` validates the critical fields (`title`, `description`, `url`,
+`author.name`, `author.email`) at build time. Problems are reported with
+`console.warn` prefixed `[site data]` rather than throwing, so a typo never
+blocks a deploy. `url` must parse as an absolute http(s) URL.
+
+## `build`
+
+Provenance for the current build, computed once and identical on every page.
+
+| Key           | Type           | Notes                                                |
+| ------------- | -------------- | ---------------------------------------------------- |
+| `time`        | string         | ISO 8601 timestamp of the build                      |
+| `version`     | string         | `version` from `package.json`                        |
+| `sha`         | string \| null | Short commit SHA, or `null` when git is unavailable  |
+| `environment` | string         | `"production"` or `"development"`                    |
+| `production`  | boolean        | `true` when `environment` is `"production"`          |
+| `label`       | string         | `"1.0.0 (abc1234)"`, or just `"1.0.0"` without a SHA |
+
+The SHA resolves in order: `GITHUB_SHA` (set by GitHub Actions), then
+`git rev-parse --short HEAD` for local builds, then `null`. The environment is
+`production` in GitHub Actions and `development` otherwise; set `ELEVENTY_ENV` to
+override.
+
+`head.njk` surfaces `build.label` and `build.time` as non-visual `<meta name>`
+tags. They survive HTML minification (comments do not) and make it easy to
+confirm which build is live.

--- a/src/_data/build.js
+++ b/src/_data/build.js
@@ -1,0 +1,52 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Build metadata exposed to templates as the global `build` object. Eleventy
+// evaluates this once per build, so every page reflects the same timestamp,
+// version, and commit.
+
+// package.json version is the stable, human-readable release marker.
+const pkg = JSON.parse(
+  readFileSync(join(process.cwd(), "package.json"), "utf8")
+);
+
+// Short commit SHA identifies the exact source a build came from. Prefer a CI
+// env var (GitHub Actions sets GITHUB_SHA); fall back to `git rev-parse` for
+// local builds; degrade to null when neither is available (e.g. a source
+// tarball with no .git checkout and no CI env). Never let a missing SHA fail
+// the build.
+function shortSha() {
+  const ciSha = process.env.GITHUB_SHA;
+  if (ciSha) {
+    return ciSha.slice(0, 7);
+  }
+  try {
+    return execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// Deploy environment. CI builds (GitHub Actions) produce the production site;
+// everything else is local development. ELEVENTY_ENV overrides both so a local
+// production dry run is possible. Templates can branch on `build.production`.
+const environment =
+  process.env.ELEVENTY_ENV ??
+  (process.env.GITHUB_ACTIONS === "true" ? "production" : "development");
+
+const sha = shortSha();
+const version = pkg.version;
+
+export default {
+  time: new Date().toISOString(),
+  version,
+  sha,
+  environment,
+  production: environment === "production",
+  // Convenience string for display: "1.0.0 (abc1234)", or "1.0.0" without git.
+  label: sha ? `${version} (${sha})` : version,
+};

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -1,4 +1,4 @@
-export default {
+const site = {
   title: "tollmanz.com",
   description: "tollmanz's personal website",
   url: "https://www.tollmanz.com",
@@ -9,3 +9,53 @@ export default {
     mastodon: "https://indieweb.social/@tollmanz",
   },
 };
+
+// Validate critical fields at build time. These values feed canonical URLs,
+// feed metadata, and Open Graph tags, so a missing or malformed value ships
+// broken SEO/social markup to every page. Warn loudly rather than throwing so a
+// typo never blocks a deploy of otherwise-good content.
+function validateSite(data) {
+  const problems = [];
+
+  for (const key of ["title", "description", "url"]) {
+    if (typeof data[key] !== "string" || data[key].trim() === "") {
+      problems.push(`site.${key} must be a non-empty string`);
+    }
+  }
+
+  if (typeof data.url === "string") {
+    try {
+      const { protocol } = new URL(data.url);
+      if (protocol !== "https:" && protocol !== "http:") {
+        problems.push("site.url must use the http or https protocol");
+      }
+    } catch {
+      problems.push("site.url must be a valid absolute URL");
+    }
+  }
+
+  if (!data.author || typeof data.author !== "object") {
+    problems.push("site.author must be an object");
+  } else {
+    if (
+      typeof data.author.name !== "string" ||
+      data.author.name.trim() === ""
+    ) {
+      problems.push("site.author.name must be a non-empty string");
+    }
+    if (
+      typeof data.author.email !== "string" ||
+      !data.author.email.includes("@")
+    ) {
+      problems.push("site.author.email must be a valid email address");
+    }
+  }
+
+  for (const problem of problems) {
+    console.warn(`[site data] ${problem}`);
+  }
+}
+
+validateSite(site);
+
+export default site;

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -33,6 +33,12 @@
   <title>{{ fullTitle }}</title>
   <meta name="description" content="{{ pageDescription }}">
 
+  {# Build provenance: which source and when this page was generated. Non-visual
+     and survives HTML minification (comments do not), so it doubles as a
+     lightweight deploy check. See src/_data/build.js and docs/data.md. #}
+  <meta name="build" content="{{ build.label }}">
+  <meta name="build-time" content="{{ build.time }}">
+
   <link href="{{ assets.css.main.url }}" rel="stylesheet" type="text/css">
   {% if content | hasCodeBlocks %}
   <link href="{{ assets.css['syntax-highlighting'].url }}" rel="stylesheet" type="text/css">


### PR DESCRIPTION
## Summary

Enhance global data management in `src/_data/` without restructuring the existing purpose-split files (`site.js`, `assets.js`, `rum.js`).

- Add `src/_data/build.js` (ESM) exposing global `build` data: `time` (ISO 8601 build timestamp), `version` (from `package.json`), `sha` (short git SHA), `environment`/`production`, and a convenience `label` string. SHA resolves in order `GITHUB_SHA` (CI) → `git rev-parse --short HEAD` (local) → `null`, so builds never fail when git is unavailable.
- Add build-time validation to `site.js` for critical fields (`title`, `description`, `url`, `author.name`, `author.email`). Problems are reported with `console.warn` prefixed `[site data]` rather than throwing, so a typo never blocks a deploy. `url` must parse as an absolute http(s) URL.
- Surface `build.label` and `build.time` as non-visual `<meta>` tags in `head.njk`. They survive HTML minification (comments are stripped by `removeComments: true`) and make the live build easy to identify, with no visual clutter.
- Document the `_data` structure in `docs/data.md` and link it from `docs/README.md`.

## Verification

- `npm run build` succeeds; confirmed `<meta name=build content="1.0.0 (6013a4f)">` and `<meta name=build-time ...>` in `public/index.html`
- `npm run lint` passes
- `npm run prettier:check` passes

## Coordination

Issues #24, #28, #29 also touch `eleventy.config.js`/config-adjacent files on sibling branches. This diff is scoped to `src/_data/`, one `head.njk` template edit, and `docs/`, so no overlap with `eleventy.config.js` is expected.

Fixes #33