### PR TITLE
feat: add configurable RUM sample rate

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -62,6 +62,11 @@ jobs:
           # the script tag (src/_data/rum.js reads it during the Eleventy build).
           RUM_MODE: production
           RUM_SERVICE_NAME: tollmanz-com-web
+          # Optional head-sampling divisor: N exports 1-in-N RUM traces, 1 =
+          # 100%. Set the RUM_SAMPLE_RATE repository variable to throttle ingest
+          # if traffic or Honeycomb quota demands it. Unset means 100% (the
+          # build step falls back to 1).
+          RUM_SAMPLE_RATE: ${{ vars.RUM_SAMPLE_RATE }}
         run: |
           node scripts/build-rum.mjs
           npx @11ty/eleventy

--- a/assets/rum/index.js
+++ b/assets/rum/index.js
@@ -9,6 +9,9 @@ import { getWebAutoInstrumentations } from "@opentelemetry/auto-instrumentations
 const mode = process.env.RUM_MODE;
 const localEndpoint = process.env.RUM_LOCAL_ENDPOINT;
 const serviceName = process.env.RUM_SERVICE_NAME;
+// Head-sampling divisor: N exports 1-in-N traces, 1 = 100%. Validated to a
+// positive integer at build time (see scripts/build-rum.mjs).
+const sampleRate = process.env.RUM_SAMPLE_RATE;
 
 // Copy the navigation's Server-Timing metrics onto a span as attributes. The
 // browser parses the header onto the navigation PerformanceEntry as
@@ -55,6 +58,7 @@ if (mode !== "off") {
   const sdk = new HoneycombWebSDK({
     endpoint,
     serviceName,
+    sampleRate,
     skipOptionsValidation: true,
     instrumentations: [
       getWebAutoInstrumentations({

--- a/scripts/build-rum.mjs
+++ b/scripts/build-rum.mjs
@@ -10,6 +10,10 @@
 //   RUM_MODE           "off" (default) | "local" | "production"
 //   RUM_LOCAL_ENDPOINT  OTLP endpoint for the local collector (default localhost:4318)
 //   RUM_SERVICE_NAME    service.name / Honeycomb dataset (default tollmanz-com-web)
+//   RUM_SAMPLE_RATE     head-sampling divisor: N exports 1-in-N traces, 1 = 100%
+//                       (default 1). The SDK stamps SampleRate so Honeycomb
+//                       reweights counts. Must be a positive integer; anything
+//                       else falls back to 1.
 //
 // When RUM_MODE is off (the default) nothing is built, so normal `npm run dev`
 // and `npm run build` ship no RUM code. head.njk only emits the script tag when
@@ -22,6 +26,16 @@ import { rm, mkdir, writeFile } from "node:fs/promises";
 const mode = process.env.RUM_MODE ?? "off";
 const localEndpoint = process.env.RUM_LOCAL_ENDPOINT ?? "http://localhost:4318";
 const serviceName = process.env.RUM_SERVICE_NAME ?? "tollmanz-com-web";
+const sampleRate = parseSampleRate(process.env.RUM_SAMPLE_RATE);
+
+// Head sampling is deterministic and divisor-based: N exports 1-in-N traces and
+// 1 keeps 100%. Only a positive integer is meaningful; unset, non-numeric, zero,
+// negative, or fractional input falls back to 1 (no sampling) rather than
+// silently dropping data.
+function parseSampleRate(raw) {
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 1 ? n : 1;
+}
 
 if (mode === "off") {
   // Clear any stale bundle from a previous enabled build.
@@ -55,6 +69,7 @@ const result = await esbuild.build({
     "process.env.RUM_MODE": JSON.stringify(mode),
     "process.env.RUM_LOCAL_ENDPOINT": JSON.stringify(localEndpoint),
     "process.env.RUM_SERVICE_NAME": JSON.stringify(serviceName),
+    "process.env.RUM_SAMPLE_RATE": JSON.stringify(sampleRate),
     "process.env.NODE_ENV": JSON.stringify("production"),
   },
 });
@@ -70,7 +85,8 @@ const outfile = `build/js/rum.${hash}.js`;
 await writeFile(outfile, bundle.contents);
 
 console.log(
-  `Built ${outfile} (RUM_MODE=${mode}, service=${serviceName}` +
+  `Built ${outfile} (RUM_MODE=${mode}, service=${serviceName}, ` +
+    `sampleRate=${sampleRate}` +
     (mode === "local" ? `, endpoint=${localEndpoint}` : "") +
     ")."
 );

--- a/tests/rum/lib/browser.js
+++ b/tests/rum/lib/browser.js
@@ -92,23 +92,31 @@ export async function runRumBundle(source, { timeoutMs = 20000 } = {}) {
   }
 }
 
+// Every span in the recorded OTLP/HTTP JSON exports, flattened out of the
+// resource/scope nesting in send order.
+export function exportedSpans(traceRequests) {
+  const spans = [];
+  for (const { body } of traceRequests) {
+    if (!body) continue;
+    for (const resource of JSON.parse(body).resourceSpans ?? []) {
+      for (const scope of resource.scopeSpans ?? []) {
+        spans.push(...(scope.spans ?? []));
+      }
+    }
+  }
+  return spans;
+}
+
 // Decode the attributes of every span named `spanName` out of the recorded
 // OTLP/HTTP JSON exports, as a flat key -> value map. An OTLP AnyValue wraps its
 // payload in exactly one typed field (stringValue, doubleValue, ...), so the
 // sole value is the attribute value whatever its type.
 export function spanAttributes(traceRequests, spanName) {
   const attributes = {};
-  for (const { body } of traceRequests) {
-    if (!body) continue;
-    for (const resource of JSON.parse(body).resourceSpans ?? []) {
-      for (const scope of resource.scopeSpans ?? []) {
-        for (const span of scope.spans ?? []) {
-          if (span.name !== spanName) continue;
-          for (const { key, value } of span.attributes ?? []) {
-            attributes[key] = Object.values(value)[0];
-          }
-        }
-      }
+  for (const span of exportedSpans(traceRequests)) {
+    if (span.name !== spanName) continue;
+    for (const { key, value } of span.attributes ?? []) {
+      attributes[key] = Object.values(value)[0];
     }
   }
   return attributes;

--- a/tests/rum/smoke.test.js
+++ b/tests/rum/smoke.test.js
@@ -22,13 +22,15 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { readFileSync, readdirSync } from "node:fs";
 import * as esbuild from "esbuild";
-import { runRumBundle, spanAttributes } from "./lib/browser.js";
+import { exportedSpans, runRumBundle, spanAttributes } from "./lib/browser.js";
 
 // Build the real bundle exactly as production does, differing only in RUM_MODE,
 // then read back the content-hashed artifact the same way src/_data/rum.js does.
-function buildLocalBundle() {
+// RUM_SAMPLE_RATE is pinned empty so an ambient value in a developer's shell
+// cannot change what is under test; the sample-rate case overrides it.
+function buildLocalBundle(env = {}) {
   execFileSync("node", ["scripts/build-rum.mjs"], {
-    env: { ...process.env, RUM_MODE: "local" },
+    env: { ...process.env, RUM_MODE: "local", RUM_SAMPLE_RATE: "", ...env },
     stdio: "pipe",
   });
   const file = readdirSync("build/js").find(name =>
@@ -36,6 +38,20 @@ function buildLocalBundle() {
   );
   assert.ok(file, "build/js should contain a rum.<hash>.js bundle");
   return readFileSync(`build/js/${file}`, "utf8");
+}
+
+// The distinct SampleRate values stamped across every exported span. The
+// Honeycomb SDK's deterministic sampler puts the configured rate on what it
+// samples, and Honeycomb reads that attribute to reweight counts, so it is where
+// the build-time knob becomes observable.
+function sampledRates(traceRequests) {
+  const rates = new Set();
+  for (const span of exportedSpans(traceRequests)) {
+    for (const { key, value } of span.attributes ?? []) {
+      if (key === "SampleRate") rates.add(Number(Object.values(value)[0]));
+    }
+  }
+  return rates;
 }
 
 // A minimal bundle that reads an undefined process.env key at load time. esbuild
@@ -106,6 +122,35 @@ test("the built RUM bundle maps Fastly Server-Timing onto the document-fetch spa
     "fastly.cache_status": "MISS",
     "fastly.total_ms": 42.1,
   });
+});
+
+// RUM_SAMPLE_RATE is silent by construction in the other direction: a build that
+// stops injecting it, or an SDK bump that renames the option, drops the SDK back
+// to its default rate of 1. Nothing throws, every assertion above stays green,
+// and production quietly ingests 100% of traffic again. Only the exported
+// SampleRate attribute distinguishes a configured rate from the default.
+//
+// Head sampling above 1 is random by design, so which traces survive a given
+// page load is not fixed. Repeat the load until one exports rather than betting
+// the suite on a single roll; at 1-in-2 a load that exports nothing at all is
+// already rare, and the bundle is built once for all attempts.
+test("the built RUM bundle samples at RUM_SAMPLE_RATE", async () => {
+  const source = buildLocalBundle({ RUM_SAMPLE_RATE: "2" });
+  let rates = new Set();
+  for (let attempt = 0; attempt < 5 && rates.size === 0; attempt++) {
+    const sampled = await runRumBundle(source, { timeoutMs: 8000 });
+    assert.deepEqual(
+      sampled.pageErrors,
+      [],
+      `sampled bundle threw: ${sampled.pageErrors.join("; ")}`
+    );
+    rates = sampledRates(sampled.traceRequests);
+  }
+  assert.deepEqual(
+    [...rates],
+    [2],
+    "exported spans should carry the configured SampleRate"
+  );
 });
 
 test("the harness catches a process reference leaking into a bundle", async () => {


### PR DESCRIPTION
## Summary

Adds a configurable head-sampling knob for the browser RUM SDK. The default is 100% (`sampleRate: 1`), so behavior is unchanged unless the knob is set. This delivers the mechanism to throttle Honeycomb ingest, not a forced rate change.

## What changed

- `scripts/build-rum.mjs`: parse `RUM_SAMPLE_RATE` to a positive integer and inject it via esbuild `define`, alongside the existing RUM defines. Unset, non-numeric, zero, negative, or fractional input falls back to `1` (no sampling)
- `assets/rum/index.js`: pass the value as `sampleRate` to `HoneycombWebSDK`
- `.github/workflows/pages.yml`: wire `RUM_SAMPLE_RATE` through the production RUM build as an optional `vars.RUM_SAMPLE_RATE` repository variable (unset means 100%)
- Documented the knob in the `build-rum.mjs` env-var header (where the other RUM env vars are documented) and in the workflow comment

## Semantics

Divisor-based deterministic head sampling: `sampleRate: N` exports 1-in-N traces, `1` = 100%. The SDK stamps `SampleRate` on spans so Honeycomb reweights counts.

## Verification

- `npm run build`, `npm run lint`, `npm run prettier:check` all pass
- `npm run build:js` with `RUM_MODE=production`:
  - unset: config carries `sampleRate` = `1`
  - `RUM_SAMPLE_RATE=10`: injected value reaches the bundle (const assigned `10`, referenced by the SDK config)
  - invalid (`abc`, `0`, `2.5`): falls back to `1`
  - confirmed by grepping the built `build/js/rum.*.js`

To enable sampling in production, set the `RUM_SAMPLE_RATE` repository variable (Settings -> Secrets and variables -> Actions -> Variables). No code change needed.

Fixes #60