### PR TITLE
feat: add build performance monitoring

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,7 +53,10 @@ jobs:
 
       # Run eleventy directly rather than `npm run build`: the build script's
       # prebuild clean wipes public/ and would delete the restored cache. A fresh
-      # runner has no stale output to clean, so skipping it is safe here.
+      # runner has no stale output to clean, so skipping it is safe here. The
+      # Eleventy invocation is wrapped with a millisecond timer so build-perf.mjs
+      # can report the duration without a second build; the directory-output
+      # plugin prints per-template metrics inline (see docs/build-performance.md).
       - name: Build site
         env:
           # Ship the RUM bundle, pointed at the same-origin /v1/traces path that
@@ -64,7 +67,23 @@ jobs:
           RUM_SERVICE_NAME: tollmanz-com-web
         run: |
           node scripts/build-rum.mjs
+          start=$(date +%s%3N)
           npx @11ty/eleventy
+          end=$(date +%s%3N)
+          echo "BUILD_PERF_DURATION_MS=$((end - start))" >> "$GITHUB_ENV"
+
+      # Compare the measured build time against perf/build-baseline.json and
+      # append a summary table to the job summary. Warns (non-blocking) on a
+      # regression beyond the threshold; see docs/build-performance.md.
+      - name: Report build performance
+        run: node scripts/build-perf.mjs
+
+      - name: Upload build metrics artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-metrics
+          path: perf/build-metrics.json
+          if-no-files-found: warn
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@ public
 # Generated RUM bundle (built by scripts/build-rum.mjs)
 build
 
+# Per-run build metrics artifact (baseline is committed, this is ephemeral)
+perf/build-metrics.json
+
 # Environment variables
 .env

--- a/.prettierignore
+++ b/.prettierignore
@@ -57,3 +57,6 @@ pnpm-lock.yaml
 # Temporary files
 *.tmp
 *.temp
+
+# Generated per-run build metrics (see scripts/build-perf.mjs)
+perf/build-metrics.json

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,5 @@ Reference documentation for tollmanz.com.
   content at the Fastly edge in front of GitHub Pages, and why
 - [edge-verification.md](edge-verification.md): the `tests/edge/` suite that
   verifies that contract against the live edge after every deploy
+- [build-performance.md](build-performance.md): how per-template and total build
+  metrics are measured, reported in CI, and guarded against regressions

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -1,0 +1,72 @@
+# Build performance
+
+How build timing is measured, reported, and guarded against regressions.
+
+## What is tracked
+
+Two things run on every build:
+
+- Per-template metrics come from the [Eleventy Directory Output
+  plugin](https://www.11ty.dev/docs/plugins/directory-output/), enabled in
+  `eleventy.config.js`. It groups Eleventy's per-file output by directory and
+  prints each template's output size and render time. Quiet mode is on so this
+  table is the single build report rather than a duplicate of Eleventy's default
+  per-file logging. Any output larger than 200 kB is highlighted.
+- Total build time is measured by `scripts/build-perf.mjs`, which also compares
+  the run against the committed baseline and writes a JSON metrics artifact.
+
+## Reading the directory-output table
+
+Each row is `output path`, `input template`, `output size`, `render time`:
+
+```
+→ about/index.html    src/pages/about.md    10.0kB    8.1ms
+```
+
+Large sizes or render times point at the templates worth optimizing first. The
+feed (`src/feed.njk`) is expected to be the largest output because it inlines
+every post.
+
+## Total build time and regression check
+
+`scripts/build-perf.mjs` records the Eleventy build duration and compares it to
+`perf/build-baseline.json`.
+
+- `npm run perf` runs the Eleventy build, times it, and prints the comparison
+- In CI the build is timed once in the `Build site` step, and the duration is
+  passed to the report step via `BUILD_PERF_DURATION_MS` so no second build runs
+- The result is written to the GitHub Actions job summary as a table
+- The per-run metrics land in `perf/build-metrics.json` (gitignored locally,
+  uploaded as the `build-metrics` artifact in CI)
+
+A run is flagged as a regression only when it is slower than the baseline by
+both more than 50% and more than one second. The absolute floor stops sub-second
+jitter on a fast build from tripping the alert. Both thresholds are constants at
+the top of `scripts/build-perf.mjs`.
+
+A regression is a warning by default: it is surfaced in the job summary and as a
+`::warning::` annotation, but the deploy still proceeds. Set
+`BUILD_PERF_FAIL_ON_REGRESSION=1` to make the report step exit non-zero and fail
+the build instead.
+
+### Why a committed baseline
+
+GitHub Pages builds have no shared storage between runs, so there is no free
+place to persist a rolling history. The committed `perf/build-baseline.json` is
+the pragmatic stand-in: one number in the repo, compared against on every run.
+The tradeoff is that the baseline is a fixed reference rather than a trend, and
+it drifts as the site grows until refreshed.
+
+## Updating the baseline
+
+Refresh the baseline when the build's steady-state time changes for a legitimate
+reason (more posts, a new plugin, a toolchain bump), so the check tracks real
+regressions rather than expected growth.
+
+- From a local warm build: `node scripts/build-perf.mjs --update-baseline`
+- From CI: read the build time in a run's job summary and set `buildMs` in
+  `perf/build-baseline.json` to that value
+
+CI hardware differs from a local machine, so prefer a CI-reported number for the
+committed baseline. The initial baseline is a seed and should be refreshed from
+the first CI run.

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -3,6 +3,7 @@ import { DateTime } from "luxon";
 import { minify } from "html-minifier-terser";
 import syntaxHighlight from "@11ty/eleventy-plugin-syntaxhighlight";
 import pluginRss from "@11ty/eleventy-plugin-rss";
+import directoryOutput from "@11ty/eleventy-plugin-directory-output";
 import { eleventyImageTransformPlugin } from "@11ty/eleventy-img";
 import CleanCSS from "clean-css";
 import markdownIt from "markdown-it";
@@ -11,6 +12,20 @@ export default function (eleventyConfig) {
   // Add plugins
   eleventyConfig.addPlugin(syntaxHighlight);
   eleventyConfig.addPlugin(pluginRss);
+
+  // Per-template build metrics: group Eleventy's per-file output by directory
+  // and show each template's output size and render time. Quiet mode suppresses
+  // Eleventy's own per-file logging so this table is the single build report.
+  // See docs/build-performance.md.
+  eleventyConfig.setQuietMode(true);
+  eleventyConfig.addPlugin(directoryOutput, {
+    columns: {
+      filesize: true,
+      benchmark: true,
+    },
+    // Flag any single output larger than 200 kB.
+    warningFileSize: 200 * 1000,
+  });
 
   // Build-time responsive images: rewrite the bare <img> that markdown-it emits
   // into <picture>/srcset with width/height. Sources are PNGs under src/media;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@11ty/eleventy": "3.1.6",
         "@11ty/eleventy-img": "6.0.4",
+        "@11ty/eleventy-plugin-directory-output": "1.0.2",
         "@11ty/eleventy-plugin-rss": "3.0.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "5.0.2",
         "@eslint/js": "10.0.1",
@@ -206,6 +207,21 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-plugin-directory-output": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-directory-output/-/eleventy-plugin-directory-output-1.0.2.tgz",
+      "integrity": "sha512-Q+ruZwZ1ow92mRqhwMW80VMF81Okl8HWthZx+dFrVIlLTkyIGQQMsrzJLwztA8KStJlJFGjzp3R1BQmz+R/cew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.4",
+        "strip-color": "^0.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4977,6 +4993,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-color": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
+      "integrity": "sha512-p9LsUieSjWNNAxVCXLeilaDlmuUOrDS5/dF9znM1nZc7EGX5+zEFC0bEevsNIaldjlks+2jns5Siz6F9iK6jwA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "dev": "npm run build:js && eleventy --serve",
     "test": "npm run test:edge",
     "test:edge": "node --test \"tests/edge/**/*.test.js\"",
+    "test:unit": "node --test \"tests/unit/**/*.test.js\"",
+    "perf": "node scripts/build-perf.mjs",
     "lint": "eslint .",
     "lint:check": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -29,6 +31,7 @@
   "devDependencies": {
     "@11ty/eleventy": "3.1.6",
     "@11ty/eleventy-img": "6.0.4",
+    "@11ty/eleventy-plugin-directory-output": "1.0.2",
     "@11ty/eleventy-plugin-rss": "3.0.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "5.0.2",
     "@eslint/js": "10.0.1",

--- a/perf/build-baseline.json
+++ b/perf/build-baseline.json
@@ -1,0 +1,6 @@
+{
+  "buildMs": 3000,
+  "recordedAt": "2026-07-16T00:00:00.000Z",
+  "node": "v24.16.0",
+  "note": "Initial seed. Refresh from a CI-reported build time once the workflow has run; see docs/build-performance.md."
+}

--- a/scripts/build-perf.mjs
+++ b/scripts/build-perf.mjs
@@ -1,0 +1,192 @@
+// Build performance tracking for the Eleventy build.
+//
+// Measures (or receives) the Eleventy build duration, writes a JSON metrics
+// artifact, and compares the duration against the committed baseline in
+// perf/build-baseline.json. A regression beyond the threshold is surfaced as a
+// warning (non-blocking by default) and written to the GitHub Actions job
+// summary. See docs/build-performance.md.
+//
+// Usage:
+//   node scripts/build-perf.mjs                 # build, time it, then report
+//   node scripts/build-perf.mjs --duration 3200 # report a pre-measured time
+//   node scripts/build-perf.mjs --update-baseline
+//
+// Env:
+//   BUILD_PERF_DURATION_MS       alternative to --duration
+//   BUILD_PERF_FAIL_ON_REGRESSION=1  exit non-zero on a regression
+//   GITHUB_STEP_SUMMARY          when set, a markdown summary is appended
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const BASELINE_PATH = path.join(ROOT, "perf", "build-baseline.json");
+const METRICS_PATH = path.join(ROOT, "perf", "build-metrics.json");
+
+// A regression is only flagged when the build is both meaningfully slower in
+// relative terms and slower by an absolute margin. The absolute floor keeps
+// sub-second jitter on a fast build from tripping the alert.
+export const RELATIVE_THRESHOLD = 0.5; // +50%
+export const ABSOLUTE_FLOOR_MS = 1000; // ignore deltas under 1s
+
+// Compare a build duration against the baseline. Pure so it can be unit tested.
+export function evaluateRegression(currentMs, baselineMs, opts = {}) {
+  const relativeThreshold = opts.relativeThreshold ?? RELATIVE_THRESHOLD;
+  const absoluteFloorMs = opts.absoluteFloorMs ?? ABSOLUTE_FLOOR_MS;
+
+  if (typeof baselineMs !== "number" || !(baselineMs > 0)) {
+    return {
+      status: "no-baseline",
+      regressed: false,
+      deltaMs: null,
+      deltaPct: null,
+    };
+  }
+
+  const deltaMs = currentMs - baselineMs;
+  const deltaPct = deltaMs / baselineMs;
+  const regressed = deltaPct > relativeThreshold && deltaMs > absoluteFloorMs;
+
+  return {
+    status: regressed ? "regressed" : "ok",
+    regressed,
+    deltaMs,
+    deltaPct,
+  };
+}
+
+function parseArgs(argv) {
+  const args = { duration: null, updateBaseline: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--duration") {
+      args.duration = Number(argv[i + 1]);
+      i += 1;
+    } else if (arg === "--update-baseline") {
+      args.updateBaseline = true;
+    }
+  }
+  return args;
+}
+
+function readBaseline() {
+  try {
+    const raw = fs.readFileSync(BASELINE_PATH, "utf8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+// Run the Eleventy build and return its wall-clock duration in milliseconds.
+function measureBuild() {
+  const start = process.hrtime.bigint();
+  const result = spawnSync("npx", ["@11ty/eleventy"], {
+    cwd: ROOT,
+    stdio: "inherit",
+    shell: false,
+  });
+  const end = process.hrtime.bigint();
+  if (result.status !== 0) {
+    throw new Error(`Eleventy build failed with exit code ${result.status}`);
+  }
+  return Number((end - start) / 1000000n);
+}
+
+function formatSeconds(ms) {
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function formatDelta(evaluation) {
+  if (evaluation.status === "no-baseline") {
+    return "no baseline";
+  }
+  const sign = evaluation.deltaMs >= 0 ? "+" : "";
+  const pct = (evaluation.deltaPct * 100).toFixed(1);
+  return `${sign}${formatSeconds(evaluation.deltaMs)} (${sign}${pct}%)`;
+}
+
+function writeSummary(metrics, baseline, evaluation) {
+  const file = process.env.GITHUB_STEP_SUMMARY;
+  if (!file) return;
+
+  const baselineCell = baseline ? formatSeconds(baseline.buildMs) : "n/a";
+  const statusLabel = {
+    ok: "✅ within threshold",
+    regressed: "⚠️ regression",
+    "no-baseline": "ℹ️ no baseline",
+  }[evaluation.status];
+
+  const lines = [
+    "## Build performance",
+    "",
+    "| Metric | Value |",
+    "| --- | --- |",
+    `| Build time | ${formatSeconds(metrics.buildMs)} |`,
+    `| Baseline | ${baselineCell} |`,
+    `| Delta | ${formatDelta(evaluation)} |`,
+    `| Threshold | +${(RELATIVE_THRESHOLD * 100).toFixed(0)}% and +${formatSeconds(ABSOLUTE_FLOOR_MS)} |`,
+    `| Status | ${statusLabel} |`,
+    "",
+  ];
+  fs.appendFileSync(file, lines.join("\n") + "\n");
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const envDuration = process.env.BUILD_PERF_DURATION_MS;
+  let buildMs;
+  if (args.duration != null && !Number.isNaN(args.duration)) {
+    buildMs = args.duration;
+  } else if (envDuration && !Number.isNaN(Number(envDuration))) {
+    buildMs = Number(envDuration);
+  } else {
+    buildMs = measureBuild();
+  }
+
+  const metrics = {
+    buildMs: Math.round(buildMs),
+    recordedAt: new Date().toISOString(),
+    node: process.version,
+  };
+
+  fs.mkdirSync(path.dirname(METRICS_PATH), { recursive: true });
+  fs.writeFileSync(METRICS_PATH, JSON.stringify(metrics, null, 2) + "\n");
+
+  const baseline = readBaseline();
+
+  if (args.updateBaseline) {
+    fs.writeFileSync(BASELINE_PATH, JSON.stringify(metrics, null, 2) + "\n");
+    console.log(`Baseline updated: ${formatSeconds(metrics.buildMs)}`);
+    return;
+  }
+
+  const evaluation = evaluateRegression(metrics.buildMs, baseline?.buildMs);
+  writeSummary(metrics, baseline, evaluation);
+
+  console.log(`Build time: ${formatSeconds(metrics.buildMs)}`);
+  if (baseline) {
+    console.log(`Baseline:   ${formatSeconds(baseline.buildMs)}`);
+    console.log(`Delta:      ${formatDelta(evaluation)}`);
+  } else {
+    console.log("Baseline:   none (run with --update-baseline to create one)");
+  }
+
+  if (evaluation.regressed) {
+    const message = `Build time regressed by ${formatDelta(evaluation)} versus baseline ${formatSeconds(baseline.buildMs)}`;
+    // GitHub Actions annotation; harmless as plain output elsewhere.
+    console.log(`::warning title=Build performance regression::${message}`);
+    if (process.env.BUILD_PERF_FAIL_ON_REGRESSION === "1") {
+      process.exitCode = 1;
+    }
+  }
+}
+
+// Only run the CLI when invoked directly, so the pure helpers can be imported
+// by tests without side effects.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tests/unit/build-perf.test.js
+++ b/tests/unit/build-perf.test.js
@@ -1,0 +1,60 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  evaluateRegression,
+  RELATIVE_THRESHOLD,
+  ABSOLUTE_FLOOR_MS,
+} from "../../scripts/build-perf.mjs";
+
+test("no baseline yields a no-baseline status", () => {
+  const result = evaluateRegression(5000, null);
+  assert.equal(result.status, "no-baseline");
+  assert.equal(result.regressed, false);
+});
+
+test("non-positive baseline is treated as missing", () => {
+  assert.equal(evaluateRegression(5000, 0).status, "no-baseline");
+  assert.equal(evaluateRegression(5000, -10).status, "no-baseline");
+});
+
+test("a faster build is within threshold", () => {
+  const result = evaluateRegression(2000, 4000);
+  assert.equal(result.status, "ok");
+  assert.equal(result.regressed, false);
+  assert.equal(result.deltaMs, -2000);
+});
+
+test("a small relative jump under the absolute floor is not a regression", () => {
+  // 500ms -> 900ms is +80% but only +400ms, below the absolute floor.
+  const result = evaluateRegression(900, 500);
+  assert.equal(result.regressed, false);
+  assert.equal(result.status, "ok");
+});
+
+test("a large absolute jump within the relative threshold is not a regression", () => {
+  // 10s -> 14s is +4s but only +40%, below the relative threshold.
+  const result = evaluateRegression(14000, 10000);
+  assert.equal(result.regressed, false);
+});
+
+test("crossing both thresholds is a regression", () => {
+  // 3s -> 6s is +100% and +3s.
+  const result = evaluateRegression(6000, 3000);
+  assert.equal(result.status, "regressed");
+  assert.equal(result.regressed, true);
+  assert.equal(result.deltaMs, 3000);
+  assert.equal(result.deltaPct, 1);
+});
+
+test("thresholds are configurable", () => {
+  const result = evaluateRegression(1200, 1000, {
+    relativeThreshold: 0.1,
+    absoluteFloorMs: 100,
+  });
+  assert.equal(result.regressed, true);
+});
+
+test("exported defaults are sane", () => {
+  assert.equal(RELATIVE_THRESHOLD, 0.5);
+  assert.equal(ABSOLUTE_FLOOR_MS, 1000);
+});


### PR DESCRIPTION
## Summary

Adds build performance monitoring and regression tracking for the Eleventy build, implemented pragmatically for a solo blog.

- Per-template metrics: integrate `@11ty/eleventy-plugin-directory-output` (pinned at 1.0.2) in `eleventy.config.js`. It prints each template's output size and render time, grouped by directory, on every build. Quiet mode is enabled so this table is the single build report rather than a duplicate of Eleventy's default per-file logging. Outputs over 200 kB are highlighted.
- Total build-time capture in CI: the `Build site` step in `pages.yml` times the Eleventy invocation in milliseconds and passes the duration to a new report step, so no second build runs.
- Benchmark/tracking: `scripts/build-perf.mjs` writes a per-run JSON metrics artifact (`perf/build-metrics.json`, gitignored locally, uploaded as the `build-metrics` artifact in CI) and compares against the committed baseline `perf/build-baseline.json`.
- Regression alerting: the check flags a run only when it is slower than the baseline by both more than 50% and more than one second (the absolute floor suppresses sub-second jitter on a fast build). By choice this is a non-blocking warning surfaced in the job summary and as a `::warning::` annotation; set `BUILD_PERF_FAIL_ON_REGRESSION=1` to make it fail the build instead.
- Documentation: `docs/build-performance.md` explains how to read the metrics, the committed-baseline approach and its tradeoff, and how to refresh the baseline.

## Baseline note

There is no shared cross-run storage in the GitHub Pages build, so the committed `perf/build-baseline.json` is the documented stand-in for a rolling history. The initial `buildMs` is a seed (3000ms); it should be refreshed from a CI-reported build time once the workflow has run, since CI hardware differs from local. See the doc for the limitation.

## Verification

- `npm run build` succeeds with the plugin enabled
- `npm run lint` and `npm run prettier:check` pass
- `npm run test:unit` (new): 8 tests covering the regression logic, all passing
- Report script exercised locally across within-threshold, warn-only regression, and fail-mode paths, including the `$GITHUB_STEP_SUMMARY` table output

Fixes #31