### PR TITLE
test: add runtime smoke test for RUM bundle

### DIFF
--- a/.github/workflows/rum-smoke.yml
+++ b/.github/workflows/rum-smoke.yml
@@ -1,0 +1,49 @@
+name: RUM smoke test
+
+# Executes the built RUM bundle in headless Chromium to catch a
+# `process is not defined`-style runtime failure (an unlisted process.env
+# reference that esbuild `define` never substitutes). Runs only when something
+# that can change the bundle changes: the RUM source, its build script, the
+# OTel/Honeycomb dependency set (path filters key on files, so the whole
+# manifest and lockfile stand in for those deps), or the test itself.
+
+on:
+  push:
+    branches: [main]
+    paths: &rum-paths
+      - "assets/rum/**"
+      - "scripts/build-rum.mjs"
+      - "package.json"
+      - "package-lock.json"
+      - "tests/rum/**"
+      - ".github/workflows/rum-smoke.yml"
+  pull_request:
+    paths: *rum-paths
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Playwright pins the browser build to the installed package version, so
+      # only Chromium is fetched. --with-deps adds the OS libraries it needs.
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run RUM smoke test
+        run: npm run test:rum

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "html-minifier-terser": "7.2.0",
         "luxon": "3.7.2",
         "markdown-it": "14.2.0",
+        "playwright": "1.61.1",
         "prettier": "3.8.4"
       },
       "engines": {
@@ -4520,6 +4521,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/please-upgrade-node": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "npm run test:unit && npm run test:edge",
     "test:unit": "node --test \"tests/unit/**/*.test.js\"",
     "test:edge": "node --test \"tests/edge/**/*.test.js\"",
+    "test:rum": "node --test \"tests/rum/**/*.test.js\"",
     "lint": "eslint .",
     "lint:check": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -42,6 +43,7 @@
     "html-minifier-terser": "7.2.0",
     "luxon": "3.7.2",
     "markdown-it": "14.2.0",
+    "playwright": "1.61.1",
     "prettier": "3.8.4"
   },
   "overrides": {

--- a/tests/rum/lib/browser.js
+++ b/tests/rum/lib/browser.js
@@ -10,31 +10,56 @@
 //
 // The bundle is served from a fake same-origin page and all network is stubbed,
 // so the test needs no live OTLP collector: OTLP exports to /v1/traces are
-// answered with 200 and recorded instead.
+// answered with 200 and recorded, payload included.
 
 import { chromium } from "playwright";
 
 const ORIGIN = "http://rum.test";
 const TRACE_RE = /\/v1\/traces(\?|$)/;
 
+// The Server-Timing header the fake page returns, mirroring what the Fastly edge
+// emits in production: the shield's backend metric first, then the edge's own
+// fields (see infra/fastly/snippets/server-timing-deliver.vcl). Serving it means
+// the bundle's addServerTimingAttributes mapping actually runs here instead of
+// taking its no-header early return, so the mapping is exercised in a browser
+// that parses the header for real rather than against a hand-built fixture.
+export const SERVER_TIMING =
+  "backend;dur=17.5, pop;desc=LHR, region;desc=Europe, " +
+  "cache_status;desc=MISS, total;dur=42.1";
+
 // Run `source` (a built IIFE bundle) in headless Chromium and collect any
 // uncaught page errors plus every OTLP trace export it attempts. Resolves once
-// a trace export is seen or a page error is thrown, whichever comes first, so a
-// clean bundle and a broken one both return promptly.
+// a trace export is recorded or a page error is thrown, whichever comes first,
+// so a clean bundle and a broken one both return promptly.
 export async function runRumBundle(source, { timeoutMs = 20000 } = {}) {
   const pageErrors = [];
   const traceRequests = [];
 
+  // Settled by the handlers below, only ever after they have recorded what they
+  // saw. Waiting on page.waitForRequest instead would race the route handler:
+  // the request event can resolve the wait before the handler stores the
+  // payload, leaving a caller to assert against a not-yet-populated array.
+  let finish;
+  let timer;
+  const settled = new Promise(resolve => {
+    finish = resolve;
+    timer = setTimeout(resolve, timeoutMs);
+  });
+
   const browser = await chromium.launch();
   try {
     const page = await browser.newPage();
-    page.on("pageerror", err => pageErrors.push(err.message));
+    page.on("pageerror", err => {
+      pageErrors.push(err.message);
+      finish();
+    });
 
     await page.route("**/*", route => {
       const url = route.request().url();
       if (url === `${ORIGIN}/`) {
         return route.fulfill({
           contentType: "text/html",
+          headers: { "Server-Timing": SERVER_TIMING },
           body: `<!doctype html><meta charset="utf-8"><title>rum smoke</title><script src="/rum.js"></script>`,
         });
       }
@@ -42,7 +67,12 @@ export async function runRumBundle(source, { timeoutMs = 20000 } = {}) {
         return route.fulfill({ contentType: "text/javascript", body: source });
       }
       if (TRACE_RE.test(url)) {
-        traceRequests.push({ url, method: route.request().method() });
+        traceRequests.push({
+          url,
+          method: route.request().method(),
+          body: route.request().postData(),
+        });
+        finish();
         return route.fulfill({
           status: 200,
           contentType: "application/json",
@@ -52,20 +82,34 @@ export async function runRumBundle(source, { timeoutMs = 20000 } = {}) {
       return route.fulfill({ status: 200, body: "" });
     });
 
-    // Resolve as soon as the bundle either exports a trace (healthy) or throws
-    // (broken); the fixed timeout is the backstop, not the expected path.
-    const settled = Promise.race([
-      page
-        .waitForRequest(req => TRACE_RE.test(req.url()), { timeout: timeoutMs })
-        .catch(() => {}),
-      page.waitForEvent("pageerror", { timeout: timeoutMs }).catch(() => {}),
-    ]);
-
     await page.goto(`${ORIGIN}/`, { waitUntil: "load" });
     await settled;
 
     return { pageErrors, traceRequests };
   } finally {
+    clearTimeout(timer);
     await browser.close();
   }
+}
+
+// Decode the attributes of every span named `spanName` out of the recorded
+// OTLP/HTTP JSON exports, as a flat key -> value map. An OTLP AnyValue wraps its
+// payload in exactly one typed field (stringValue, doubleValue, ...), so the
+// sole value is the attribute value whatever its type.
+export function spanAttributes(traceRequests, spanName) {
+  const attributes = {};
+  for (const { body } of traceRequests) {
+    if (!body) continue;
+    for (const resource of JSON.parse(body).resourceSpans ?? []) {
+      for (const scope of resource.scopeSpans ?? []) {
+        for (const span of scope.spans ?? []) {
+          if (span.name !== spanName) continue;
+          for (const { key, value } of span.attributes ?? []) {
+            attributes[key] = Object.values(value)[0];
+          }
+        }
+      }
+    }
+  }
+  return attributes;
 }

--- a/tests/rum/lib/browser.js
+++ b/tests/rum/lib/browser.js
@@ -1,0 +1,71 @@
+// Loads a built RUM bundle in a real headless browser and reports what happened.
+//
+// The point is to execute the delivered bytes the way a visitor's browser
+// would, so a `process is not defined`-style ReferenceError (an unlisted
+// process.env reference that esbuild `define` never substituted) surfaces as an
+// uncaught page error rather than passing an "esbuild built it" check. A Node
+// vm sandbox cannot stand in here: the Honeycomb Web SDK touches enough browser
+// surface (screen, PerformanceObserver, fetch, XHR) that a hand-rolled shim
+// throws for the wrong reasons, masking the very failure this guard exists for.
+//
+// The bundle is served from a fake same-origin page and all network is stubbed,
+// so the test needs no live OTLP collector: OTLP exports to /v1/traces are
+// answered with 200 and recorded instead.
+
+import { chromium } from "playwright";
+
+const ORIGIN = "http://rum.test";
+const TRACE_RE = /\/v1\/traces(\?|$)/;
+
+// Run `source` (a built IIFE bundle) in headless Chromium and collect any
+// uncaught page errors plus every OTLP trace export it attempts. Resolves once
+// a trace export is seen or a page error is thrown, whichever comes first, so a
+// clean bundle and a broken one both return promptly.
+export async function runRumBundle(source, { timeoutMs = 20000 } = {}) {
+  const pageErrors = [];
+  const traceRequests = [];
+
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    page.on("pageerror", err => pageErrors.push(err.message));
+
+    await page.route("**/*", route => {
+      const url = route.request().url();
+      if (url === `${ORIGIN}/`) {
+        return route.fulfill({
+          contentType: "text/html",
+          body: `<!doctype html><meta charset="utf-8"><title>rum smoke</title><script src="/rum.js"></script>`,
+        });
+      }
+      if (url === `${ORIGIN}/rum.js`) {
+        return route.fulfill({ contentType: "text/javascript", body: source });
+      }
+      if (TRACE_RE.test(url)) {
+        traceRequests.push({ url, method: route.request().method() });
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: "{}",
+        });
+      }
+      return route.fulfill({ status: 200, body: "" });
+    });
+
+    // Resolve as soon as the bundle either exports a trace (healthy) or throws
+    // (broken); the fixed timeout is the backstop, not the expected path.
+    const settled = Promise.race([
+      page
+        .waitForRequest(req => TRACE_RE.test(req.url()), { timeout: timeoutMs })
+        .catch(() => {}),
+      page.waitForEvent("pageerror", { timeout: timeoutMs }).catch(() => {}),
+    ]);
+
+    await page.goto(`${ORIGIN}/`, { waitUntil: "load" });
+    await settled;
+
+    return { pageErrors, traceRequests };
+  } finally {
+    await browser.close();
+  }
+}

--- a/tests/rum/smoke.test.js
+++ b/tests/rum/smoke.test.js
@@ -11,13 +11,18 @@
 // A `process`/`global` shim injected via esbuild would silence that error, but
 // it would also hide the leak from this guard, so the bundle deliberately has
 // no shim: this test is the safety net instead.
+//
+// The same bump can break the bundle without throwing at all. The Fastly
+// Server-Timing mapping rides on an OTel instrumentation config key, and the
+// instrumentation swallows anything that callback throws, so that half is
+// checked against the exported OTLP payload rather than the page's error log.
 
 import { test, before } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { readFileSync, readdirSync } from "node:fs";
 import * as esbuild from "esbuild";
-import { runRumBundle } from "./lib/browser.js";
+import { runRumBundle, spanAttributes } from "./lib/browser.js";
 
 // Build the real bundle exactly as production does, differing only in RUM_MODE,
 // then read back the content-hashed artifact the same way src/_data/rum.js does.
@@ -50,34 +55,57 @@ async function buildLeakyBundle() {
   return result.outputFiles[0].text;
 }
 
-let bundle;
+let run;
 
-before(() => {
-  bundle = buildLocalBundle();
+// One page load backs every assertion below: the bundle either loads cleanly and
+// exports once, or it does not, and three separate browser launches would only
+// pay the exporter's batch delay three times over to observe the same thing.
+before(async () => {
+  run = await runRumBundle(buildLocalBundle());
 });
 
-test("the built RUM bundle initializes without a process reference error", async () => {
-  const { pageErrors } = await runRumBundle(bundle);
-  const leak = pageErrors.find(msg => /process is not defined/i.test(msg));
+test("the built RUM bundle initializes without a process reference error", () => {
+  const leak = run.pageErrors.find(msg => /process is not defined/i.test(msg));
   assert.equal(
     leak,
     undefined,
     `bundle threw a process reference error: ${leak}`
   );
   assert.deepEqual(
-    pageErrors,
+    run.pageErrors,
     [],
-    `bundle initialization threw: ${pageErrors.join("; ")}`
+    `bundle initialization threw: ${run.pageErrors.join("; ")}`
   );
 });
 
-test("the built RUM bundle exports telemetry to /v1/traces", async () => {
-  const { traceRequests } = await runRumBundle(bundle);
+test("the built RUM bundle exports telemetry to /v1/traces", () => {
   assert.ok(
-    traceRequests.length > 0,
+    run.traceRequests.length > 0,
     "expected at least one OTLP export to /v1/traces"
   );
-  assert.equal(traceRequests[0].method, "POST");
+  assert.equal(run.traceRequests[0].method, "POST");
+});
+
+// The bundle reads the navigation's Server-Timing metrics and copies them onto
+// the document-fetch span. That mapping hangs off an OTel instrumentation config
+// key (applyCustomAttributesOnSpan.documentFetch), and a throw inside that
+// callback is swallowed by the instrumentation rather than raised as a page
+// error, so a dependency bump could sever the Fastly edge telemetry without any
+// of the assertions above going red. Only the exported payload shows it.
+test("the built RUM bundle maps Fastly Server-Timing onto the document-fetch span", () => {
+  const attributes = spanAttributes(run.traceRequests, "documentFetch");
+  const fastly = Object.fromEntries(
+    Object.entries(attributes).filter(([key]) => key.startsWith("fastly."))
+  );
+  // Each header field yields exactly one attribute: a dur field a numeric
+  // <name>_ms, a desc field a string <name>. Neither kind produces the other.
+  assert.deepEqual(fastly, {
+    "fastly.backend_ms": 17.5,
+    "fastly.pop": "LHR",
+    "fastly.region": "Europe",
+    "fastly.cache_status": "MISS",
+    "fastly.total_ms": 42.1,
+  });
 });
 
 test("the harness catches a process reference leaking into a bundle", async () => {

--- a/tests/rum/smoke.test.js
+++ b/tests/rum/smoke.test.js
@@ -1,0 +1,90 @@
+// Runtime guard for the browser RUM bundle (see PR #45 and issue #61).
+//
+// esbuild `define` only substitutes the process.env keys listed in
+// scripts/build-rum.mjs. An @opentelemetry/* or @honeycombio/* bump that adds
+// an unlisted process.env reference would ship a bare `process` into the bundle
+// and throw `process is not defined` in the browser, and nothing downstream of
+// "esbuild built it" would notice. These tests build the real RUM bundle with
+// RUM_MODE=local and execute it in headless Chromium, so such a leak fails the
+// build here rather than in a visitor's console.
+//
+// A `process`/`global` shim injected via esbuild would silence that error, but
+// it would also hide the leak from this guard, so the bundle deliberately has
+// no shim: this test is the safety net instead.
+
+import { test, before } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import * as esbuild from "esbuild";
+import { runRumBundle } from "./lib/browser.js";
+
+// Build the real bundle exactly as production does, differing only in RUM_MODE,
+// then read back the content-hashed artifact the same way src/_data/rum.js does.
+function buildLocalBundle() {
+  execFileSync("node", ["scripts/build-rum.mjs"], {
+    env: { ...process.env, RUM_MODE: "local" },
+    stdio: "pipe",
+  });
+  const file = readdirSync("build/js").find(name =>
+    /^rum\.[0-9a-f]{8,}\.js$/.test(name)
+  );
+  assert.ok(file, "build/js should contain a rum.<hash>.js bundle");
+  return readFileSync(`build/js/${file}`, "utf8");
+}
+
+// A minimal bundle that reads an undefined process.env key at load time. esbuild
+// leaves the reference untouched (it is not in `define`), reproducing exactly
+// the leak an OTel/Honeycomb bump could introduce. Used as a negative control to
+// prove the browser harness actually catches the failure mode.
+async function buildLeakyBundle() {
+  const result = await esbuild.build({
+    stdin: {
+      contents: "window.__rumLeak = process.env.OTEL_UNSET_AT_BUILD_TIME;",
+      loader: "js",
+    },
+    bundle: true,
+    format: "iife",
+    write: false,
+  });
+  return result.outputFiles[0].text;
+}
+
+let bundle;
+
+before(() => {
+  bundle = buildLocalBundle();
+});
+
+test("the built RUM bundle initializes without a process reference error", async () => {
+  const { pageErrors } = await runRumBundle(bundle);
+  const leak = pageErrors.find(msg => /process is not defined/i.test(msg));
+  assert.equal(
+    leak,
+    undefined,
+    `bundle threw a process reference error: ${leak}`
+  );
+  assert.deepEqual(
+    pageErrors,
+    [],
+    `bundle initialization threw: ${pageErrors.join("; ")}`
+  );
+});
+
+test("the built RUM bundle exports telemetry to /v1/traces", async () => {
+  const { traceRequests } = await runRumBundle(bundle);
+  assert.ok(
+    traceRequests.length > 0,
+    "expected at least one OTLP export to /v1/traces"
+  );
+  assert.equal(traceRequests[0].method, "POST");
+});
+
+test("the harness catches a process reference leaking into a bundle", async () => {
+  const leaky = await buildLeakyBundle();
+  const { pageErrors } = await runRumBundle(leaky, { timeoutMs: 5000 });
+  assert.ok(
+    pageErrors.some(msg => /process is not defined/i.test(msg)),
+    `expected a "process is not defined" page error, got: ${JSON.stringify(pageErrors)}`
+  );
+});


### PR DESCRIPTION
## Summary

Adds a runtime guard for the browser RUM bundle. esbuild `define` only
substitutes the `process.env.*` keys listed in `scripts/build-rum.mjs`; an
`@opentelemetry/*` or `@honeycombio/*` bump that introduces an unlisted
`process.env` reference would ship a bare `process` into the bundle and throw
`process is not defined` in the browser, with nothing between "esbuild built it"
and a visitor's console to catch it.

The test builds the real bundle with `RUM_MODE=local` and executes it in
headless Chromium (Playwright), asserting:
* init throws no `process is not defined` (and no other) page error
* an OTLP export reaches `/v1/traces`, proving the SDK actually started
* the Fastly Server-Timing metrics reach the exported document-fetch span

A fourth test is a negative control: it bundles a deliberate `process.env` leak
and confirms the harness reports `process is not defined`, so the guard is
proven to exercise the delivered bytes rather than just that esbuild ran.

## Server-Timing coverage

Rebasing onto main picked up the Fastly edge timing work (#75), which gave the
bundle a second runtime surface: `addServerTimingAttributes` copies the
navigation's Server-Timing metrics onto the document-fetch span. The guard as
originally written could not see it, for two compounding reasons. The fake page
served no `Server-Timing` header, so the mapping took its no-header early return
and never ran. And a throw inside `applyCustomAttributesOnSpan` is swallowed by
the instrumentation rather than raised as a page error, so the page-error
assertion stays green even when the mapping is broken. An OTel bump could
therefore sever the edge telemetry silently, which is the failure class this
guard exists for.

The harness now serves a `Server-Timing` header shaped like the one the edge
emits and records the OTLP payload, and the new test asserts the `fastly.*`
attributes on the exported document-fetch span.

## Why a real browser

A Node `vm` sandbox cannot stand in here. The Honeycomb Web SDK touches enough
browser surface (`screen`, `PerformanceObserver`, `fetch`, `XHR`) that a
hand-rolled shim throws for the wrong reasons, masking the very failure this
guard exists for. Playwright is pinned (`1.61.1`) and the CI job fetches only
Chromium.

## Belt-and-suspenders shim: deliberately omitted

The issue suggests considering a `process`/`global` shim via esbuild `inject`.
That would make the bundle robust to a leak, but it would also silence the
`process is not defined` error and hide the leak from this test. The runtime
guard is the more valuable of the two, so no shim is added and
`scripts/build-rum.mjs` is left untouched.

## Changes

* `tests/rum/smoke.test.js`, `tests/rum/lib/browser.js`: the smoke test and its
  browser harness
* `package.json`: `test:rum` script and a pinned `playwright` devDependency
* `.github/workflows/rum-smoke.yml`: CI job scoped to changes in `assets/rum/**`,
  `scripts/build-rum.mjs`, the dependency manifest/lockfile, and the test itself

`test:rum` stays out of `npm test` because it needs a Chromium download that
`test:unit` and `test:edge` do not.

## Verification

`npm run test:rum` passes locally and in CI. The Server-Timing test was checked
against three mutations of `assets/rum/index.js`: a throw inside the callback,
the `applyCustomAttributesOnSpan` wiring removed, and the `_ms` suffix renamed.
Each reddens only that test. The negative control fails loudly if `process`
leaks in. `npm run build`, `npm run lint:check`, `npm run prettier:check`, and
`npm run test:unit` all pass.

Two harness fixes came out of the rebase. The run now settles from the handlers
that record the request, not from `page.waitForRequest`, which the request event
could resolve before the route handler stored anything; the old assertion passed
on timing alone. And one page load now backs all three assertions about the
working bundle instead of one browser launch per test, which cuts the suite from
roughly 12s to 6s.

## Coordination

#60 also edits `scripts/build-rum.mjs` and `assets/rum/index.js`; this PR
touches neither.

Fixes #61
