### PR TITLE
feat: Server-Timing headers into OTel RUM

### DIFF
--- a/assets/rum/index.js
+++ b/assets/rum/index.js
@@ -11,29 +11,32 @@ const localEndpoint = process.env.RUM_LOCAL_ENDPOINT;
 const serviceName = process.env.RUM_SERVICE_NAME;
 
 // Copy the navigation's Server-Timing metrics onto a span as attributes. The
-// Fastly edge emits `origin` and `edge` metrics (backend vs edge processing
-// time), which the browser parses onto the navigation PerformanceEntry as
-// entry.serverTiming: an array of { name, duration, description }. This maps
-// each metric generically to server_timing.<name>.{duration_ms,description}, so
-// adding a metric in the VCL needs no change here. duration is exposed in full
-// because the header is same-origin; on a cache hit the origin metric is absent
-// or 0, which is the honest signal that the backend did no work.
+// browser parses the header onto the navigation PerformanceEntry as
+// entry.serverTiming: an array of { name, duration, description }. The Fastly
+// edge emits one metric per field, naming each for what it describes rather than
+// for the node that measured it (see
+// infra/fastly/snippets/server-timing-deliver.vcl), so the mapping here stays
+// generic and a new field in the VCL needs no change to this file:
+//
+//   pop;desc=LHR      -> fastly.pop = "LHR"
+//   total;dur=42.1    -> fastly.total_ms = 42.1
+//
+// Durations are exposed in full because the header is same-origin. `backend` is
+// absent whenever the edge answered from its own cache, which is the honest
+// signal that no backend work happened on this request.
 function addServerTimingAttributes(span) {
   const [navigation] = performance.getEntriesByType("navigation");
   const metrics = navigation?.serverTiming;
   if (!metrics) return;
   for (const metric of metrics) {
-    if (typeof metric.duration === "number") {
-      span.setAttribute(
-        `server_timing.${metric.name}.duration_ms`,
-        metric.duration
-      );
+    // `duration` is specified as 0 when the metric carries no dur param, which
+    // is every description-only field, so only a positive value is a real
+    // measurement. A typeof check would pass for all of them.
+    if (metric.duration > 0) {
+      span.setAttribute(`fastly.${metric.name}_ms`, metric.duration);
     }
     if (metric.description) {
-      span.setAttribute(
-        `server_timing.${metric.name}.description`,
-        metric.description
-      );
+      span.setAttribute(`fastly.${metric.name}`, metric.description);
     }
   }
 }
@@ -57,10 +60,11 @@ if (mode !== "off") {
       getWebAutoInstrumentations({
         "@opentelemetry/instrumentation-fetch": { ignoreUrls },
         "@opentelemetry/instrumentation-xml-http-request": { ignoreUrls },
-        // Attach the Server-Timing metrics the Fastly edge emits (backend vs
-        // edge processing time; see infra/fastly/snippets/server-timing-deliver.vcl)
-        // to the document-fetch span, which is the span for the navigation
-        // request the header describes.
+        // Attach the Server-Timing fields the Fastly edge emits (POP, cache
+        // status and timings; see
+        // infra/fastly/snippets/server-timing-deliver.vcl) to the document-fetch
+        // span, which is the span for the navigation request the header
+        // describes.
         "@opentelemetry/instrumentation-document-load": {
           applyCustomAttributesOnSpan: {
             documentFetch: addServerTimingAttributes,

--- a/assets/rum/index.js
+++ b/assets/rum/index.js
@@ -10,6 +10,34 @@ const mode = process.env.RUM_MODE;
 const localEndpoint = process.env.RUM_LOCAL_ENDPOINT;
 const serviceName = process.env.RUM_SERVICE_NAME;
 
+// Copy the navigation's Server-Timing metrics onto a span as attributes. The
+// Fastly edge emits `origin` and `edge` metrics (backend vs edge processing
+// time), which the browser parses onto the navigation PerformanceEntry as
+// entry.serverTiming: an array of { name, duration, description }. This maps
+// each metric generically to server_timing.<name>.{duration_ms,description}, so
+// adding a metric in the VCL needs no change here. duration is exposed in full
+// because the header is same-origin; on a cache hit the origin metric is absent
+// or 0, which is the honest signal that the backend did no work.
+function addServerTimingAttributes(span) {
+  const [navigation] = performance.getEntriesByType("navigation");
+  const metrics = navigation?.serverTiming;
+  if (!metrics) return;
+  for (const metric of metrics) {
+    if (typeof metric.duration === "number") {
+      span.setAttribute(
+        `server_timing.${metric.name}.duration_ms`,
+        metric.duration
+      );
+    }
+    if (metric.description) {
+      span.setAttribute(
+        `server_timing.${metric.name}.description`,
+        metric.description
+      );
+    }
+  }
+}
+
 if (mode !== "off") {
   // local: post to the local OTLP collector (see local/otel).
   // production: post to the same-origin /v1/traces path, which the Fastly edge
@@ -29,6 +57,15 @@ if (mode !== "off") {
       getWebAutoInstrumentations({
         "@opentelemetry/instrumentation-fetch": { ignoreUrls },
         "@opentelemetry/instrumentation-xml-http-request": { ignoreUrls },
+        // Attach the Server-Timing metrics the Fastly edge emits (backend vs
+        // edge processing time; see infra/fastly/snippets/server-timing-deliver.vcl)
+        // to the document-fetch span, which is the span for the navigation
+        // request the header describes.
+        "@opentelemetry/instrumentation-document-load": {
+          applyCustomAttributesOnSpan: {
+            documentFetch: addServerTimingAttributes,
+          },
+        },
       }),
       new WebVitalsInstrumentation(),
     ],

--- a/docs/edge-caching.md
+++ b/docs/edge-caching.md
@@ -133,6 +133,33 @@ The same Fastly service sets the rest of the edge behavior:
   a 301 that preserves the path and query, synthesized at the edge from the
   `apex-to-www-recv.vcl` and `apex-to-www-error.vcl` snippets
 
+## Server-Timing for RUM
+
+`infra/fastly/snippets/server-timing-deliver.vcl` runs in `vcl_deliver` and emits
+a `Server-Timing` header so the browser can attribute how long the backend took
+versus the edge. The browser RUM bundle reads the parsed metrics from the
+navigation `PerformanceEntry` (`entry.serverTiming`) and attaches them to the
+OpenTelemetry document-fetch span, one attribute per metric
+(`server_timing.<name>.duration_ms` and `.description`), so backend latency is
+queryable in Honeycomb alongside the RUM traces.
+
+`vcl_deliver` runs at both the customer-facing edge POP and the `iad-va-us`
+shield POP, so the two nodes split the work:
+
+| Metric   | Set by     | Meaning                                                                                                       |
+| -------- | ---------- | ------------------------------------------------------------------------------------------------------------- |
+| `origin` | shield POP | the shield's total time (`time.elapsed`), dominated by the GitHub Pages fetch; near `0` on a shield cache hit |
+| `edge`   | edge POP   | `time.elapsed`, the total time the request spent in the customer edge POP, including the backend wait         |
+
+`desc` on each metric carries `fastly_info.state` (`HIT`, `MISS`, `PASS`, ...),
+so a reader can tell whether a duration reflects real backend work or a cache
+serve. The shield sets the `origin` metric and the edge appends `edge`; the edge
+uses `req.http.Fastly-FF` to tell the two nodes apart. On an edge cache hit the
+request never reaches the shield, so the header carries only the `edge` metric,
+and the snippet discards any `origin` value cached with the object rather than
+reporting a stale fill time. The header is same-origin, so the browser exposes
+the full durations to script with no `Timing-Allow-Origin` needed.
+
 ## How a deploy reaches the edge
 
 Two pipelines fire on a push to `main`, each owning one half of the contract:
@@ -186,6 +213,10 @@ curl -sI -H "If-None-Match: $ETAG" https://www.tollmanz.com/ | head -1 # 304
 # Compression
 curl -sI -H 'Accept-Encoding: br' https://www.tollmanz.com/ | grep -i content-encoding   # br
 curl -sI -H 'Accept-Encoding: gzip' https://www.tollmanz.com/ | grep -i content-encoding # gzip
+
+# Server-Timing (edge metric always present; origin metric on a cache miss)
+curl -sI https://www.tollmanz.com/ | grep -i server-timing                    # edge;desc=...;dur=...
+curl -sI "https://www.tollmanz.com/?bust=$(date +%s)" | grep -i server-timing  # origin;...;dur=..., edge;...
 
 # HTTP/3 advertisement and TLS 0-RTT
 curl -sI https://www.tollmanz.com/ | grep -i alt-svc                  # h3=":443"

--- a/docs/edge-caching.md
+++ b/docs/edge-caching.md
@@ -136,29 +136,51 @@ The same Fastly service sets the rest of the edge behavior:
 ## Server-Timing for RUM
 
 `infra/fastly/snippets/server-timing-deliver.vcl` runs in `vcl_deliver` and emits
-a `Server-Timing` header so the browser can attribute how long the backend took
-versus the edge. The browser RUM bundle reads the parsed metrics from the
-navigation `PerformanceEntry` (`entry.serverTiming`) and attaches them to the
-OpenTelemetry document-fetch span, one attribute per metric
-(`server_timing.<name>.duration_ms` and `.description`), so backend latency is
-queryable in Honeycomb alongside the RUM traces.
+a `Server-Timing` header so the browser can attribute server-side latency. The
+RUM bundle reads the parsed metrics from the navigation `PerformanceEntry`
+(`entry.serverTiming`) and attaches them to the OpenTelemetry document-fetch
+span, so POP, cache status and backend latency are queryable in Honeycomb
+alongside the RUM traces.
+
+Each metric name is a field name rather than the node that measured it, which
+keeps the browser-side mapping generic: a `desc` becomes `fastly.<name>` and a
+`dur` becomes `fastly.<name>_ms`. Adding a field in the VCL therefore needs no
+JavaScript change. The browser surfaces only `name`, `desc` and `dur` from a
+metric, so a field carries at most one string and one number.
+
+| Field          | Attribute             | Meaning                                                                 |
+| -------------- | --------------------- | ----------------------------------------------------------------------- |
+| `pop`          | `fastly.pop`          | `server.datacenter`, the customer-facing POP serving the visitor        |
+| `region`       | `fastly.region`       | `server.region`, one of a fixed 16-value list such as `EU-West`         |
+| `cache_status` | `fastly.cache_status` | how deep the request went: `HIT`, `SHIELD_HIT`, `MISS`, `PASS`          |
+| `total`        | `fastly.total_ms`     | total time inside Fastly, from edge receipt to response                 |
+| `backend`      | `fastly.backend_ms`   | time the shield spent fetching from GitHub Pages; absent on an edge hit |
+
+Fastly's own overhead is `total` minus `backend`.
 
 `vcl_deliver` runs at both the customer-facing edge POP and the `iad-va-us`
-shield POP, so the two nodes split the work:
+shield POP, which the snippet tells apart with `req.http.Fastly-FF`. The shield
+reports what only it can measure (`backend`, plus its own `fastly_info.state` on
+an internal `Fastly-Shield-State` header) and the edge assembles the final
+header, stripping the internal header before delivery. On an edge cache hit the
+request never reaches the shield, so the snippet discards any `backend` value
+cached with the object rather than reporting a stale fill time.
 
-| Metric   | Set by     | Meaning                                                                                                       |
-| -------- | ---------- | ------------------------------------------------------------------------------------------------------------- |
-| `origin` | shield POP | the shield's total time (`time.elapsed`), dominated by the GitHub Pages fetch; near `0` on a shield cache hit |
-| `edge`   | edge POP   | `time.elapsed`, the total time the request spent in the customer edge POP, including the backend wait         |
+`cache_status` is derived to a single value so one group-by answers how deep a
+request went. `SHIELD_HIT` means the edge missed but the shield answered from its
+own cache, which a bare edge `MISS` would hide. The cost of collapsing to one
+field is that an edge state and a shield state cannot both be reported: an edge
+`HIT-STALE` served over a shield `MISS` reports only the edge's state.
 
-`desc` on each metric carries `fastly_info.state` (`HIT`, `MISS`, `PASS`, ...),
-so a reader can tell whether a duration reflects real backend work or a cache
-serve. The shield sets the `origin` metric and the edge appends `edge`; the edge
-uses `req.http.Fastly-FF` to tell the two nodes apart. On an edge cache hit the
-request never reaches the shield, so the header carries only the `edge` metric,
-and the snippet discards any `origin` value cached with the object rather than
-reporting a stale fill time. The header is same-origin, so the browser exposes
-the full durations to script with no `Timing-Allow-Origin` needed.
+Two known gaps. Fastly skips the redundant hop for a visitor whose nearest POP is
+already the shield, so one node plays both roles, `Fastly-FF` is unset, and no
+`backend` metric exists even though the origin was contacted; those requests
+report a `MISS` with no backend timing. Separately, `fastly.pop` is a coarse
+visitor geolocation signal, roughly 100-cardinality, which on a low-traffic site
+is fairly identifying when joined with a timestamp.
+
+The header is same-origin, so the browser exposes the full durations to script
+with no `Timing-Allow-Origin` needed.
 
 ## How a deploy reaches the edge
 
@@ -214,9 +236,9 @@ curl -sI -H "If-None-Match: $ETAG" https://www.tollmanz.com/ | head -1 # 304
 curl -sI -H 'Accept-Encoding: br' https://www.tollmanz.com/ | grep -i content-encoding   # br
 curl -sI -H 'Accept-Encoding: gzip' https://www.tollmanz.com/ | grep -i content-encoding # gzip
 
-# Server-Timing (edge metric always present; origin metric on a cache miss)
-curl -sI https://www.tollmanz.com/ | grep -i server-timing                    # edge;desc=...;dur=...
-curl -sI "https://www.tollmanz.com/?bust=$(date +%s)" | grep -i server-timing  # origin;...;dur=..., edge;...
+# Server-Timing (pop/region/cache_status/total always present; backend on a miss)
+curl -sI https://www.tollmanz.com/ | grep -i server-timing                    # pop;desc=..., cache_status;desc=HIT, total;dur=...
+curl -sI "https://www.tollmanz.com/?bust=$(date +%s)" | grep -i server-timing  # backend;dur=..., cache_status;desc=MISS, ...
 
 # HTTP/3 advertisement and TLS 0-RTT
 curl -sI https://www.tollmanz.com/ | grep -i alt-svc                  # h3=":443"

--- a/docs/edge-verification.md
+++ b/docs/edge-verification.md
@@ -7,15 +7,15 @@ unit tests cannot see. It runs after every deploy and on a weekly schedule.
 
 ## What it checks
 
-| File                         | Checks                                                                                                                                 |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `cache-control.test.js`      | Cache-Control per asset class (HTML, feed, sitemap, fingerprinted CSS, fonts, favicon); a 404 is never immutable                       |
-| `revalidation.test.js`       | HTML carries an ETag; a conditional request returns 304                                                                                |
-| `compression.test.js`        | brotli, gzip, and identity negotiation; brotli preferred; Vary on Accept-Encoding; fonts not re-compressed; brotli shrinks the payload |
-| `protocols.test.js`          | HTTP/2 negotiated; HTTP/3 advertised via alt-svc; a real HTTP/3 round trip when the runner's curl supports it                          |
-| `tls.test.js`                | TLS 1.3 and TLS 1.2 accepted; session resumption; 0-RTT early data accepted                                                            |
-| `redirects-security.test.js` | HTTP upgrades to HTTPS; apex redirects to www preserving the path; HSTS set with a long max-age                                        |
-| `server-timing.test.js`      | HTML carries a Server-Timing header with an `edge` metric; a cache-busting request adds the `origin` backend metric                    |
+| File                         | Checks                                                                                                                                                                             |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cache-control.test.js`      | Cache-Control per asset class (HTML, feed, sitemap, fingerprinted CSS, fonts, favicon); a 404 is never immutable                                                                   |
+| `revalidation.test.js`       | HTML carries an ETag; a conditional request returns 304                                                                                                                            |
+| `compression.test.js`        | brotli, gzip, and identity negotiation; brotli preferred; Vary on Accept-Encoding; fonts not re-compressed; brotli shrinks the payload                                             |
+| `protocols.test.js`          | HTTP/2 negotiated; HTTP/3 advertised via alt-svc; a real HTTP/3 round trip when the runner's curl supports it                                                                      |
+| `tls.test.js`                | TLS 1.3 and TLS 1.2 accepted; session resumption; 0-RTT early data accepted                                                                                                        |
+| `redirects-security.test.js` | HTTP upgrades to HTTPS; apex redirects to www preserving the path; HSTS set with a long max-age                                                                                    |
+| `server-timing.test.js`      | HTML carries the `pop`, `region`, `cache_status` and `total` fields; a cache-busting request reports a non-HIT status and `backend` timing; the internal shield header never leaks |
 
 ## Running it
 

--- a/docs/edge-verification.md
+++ b/docs/edge-verification.md
@@ -15,6 +15,7 @@ unit tests cannot see. It runs after every deploy and on a weekly schedule.
 | `protocols.test.js`          | HTTP/2 negotiated; HTTP/3 advertised via alt-svc; a real HTTP/3 round trip when the runner's curl supports it                          |
 | `tls.test.js`                | TLS 1.3 and TLS 1.2 accepted; session resumption; 0-RTT early data accepted                                                            |
 | `redirects-security.test.js` | HTTP upgrades to HTTPS; apex redirects to www preserving the path; HSTS set with a long max-age                                        |
+| `server-timing.test.js`      | HTML carries a Server-Timing header with an `edge` metric; a cache-busting request adds the `origin` backend metric                    |
 
 ## Running it
 

--- a/infra/fastly/index.ts
+++ b/infra/fastly/index.ts
@@ -228,9 +228,10 @@ const site = new fastly.ServiceVcl(
         content: forceIdentityFetch,
       },
       {
-        // Server-Timing (backend vs edge) for browser RUM. Runs at both the edge
-        // and shield POP; the snippet uses req.http.Fastly-FF to tell them apart
-        // and assembles the header at the edge. See the snippet for the split.
+        // Server-Timing (POP, cache status, timings) for browser RUM. Runs at
+        // both the edge and shield POP; the snippet uses req.http.Fastly-FF to
+        // tell them apart and assembles the header at the edge. See the snippet
+        // for the split and the field names.
         name: "Server-Timing for RUM",
         type: "deliver",
         priority: 100,

--- a/infra/fastly/index.ts
+++ b/infra/fastly/index.ts
@@ -38,6 +38,10 @@ const forceIdentityFetch = fs.readFileSync(
   path.join(snippetsDir, "force-identity-fetch.vcl"),
   "utf8"
 );
+const serverTimingDeliver = fs.readFileSync(
+  path.join(snippetsDir, "server-timing-deliver.vcl"),
+  "utf8"
+);
 
 const honeycombProxy = fs.readFileSync(
   path.join(snippetsDir, "honeycomb-proxy.vcl"),
@@ -222,6 +226,15 @@ const site = new fastly.ServiceVcl(
         type: "pass",
         priority: 100,
         content: forceIdentityFetch,
+      },
+      {
+        // Server-Timing (backend vs edge) for browser RUM. Runs at both the edge
+        // and shield POP; the snippet uses req.http.Fastly-FF to tell them apart
+        // and assembles the header at the edge. See the snippet for the split.
+        name: "Server-Timing for RUM",
+        type: "deliver",
+        priority: 100,
+        content: serverTimingDeliver,
       },
     ],
   },

--- a/infra/fastly/snippets/server-timing-deliver.vcl
+++ b/infra/fastly/snippets/server-timing-deliver.vcl
@@ -1,0 +1,51 @@
+# Emit a Server-Timing header so the browser can see how long the backend took
+# versus the edge. The RUM bundle reads the parsed metrics from the navigation
+# PerformanceEntry (entry.serverTiming) and attaches them to the OpenTelemetry
+# document-fetch span (see assets/rum/index.js). Server-Timing is exposed to
+# same-origin script with no Timing-Allow-Origin needed, and the site is
+# same-origin, so the browser populates entry.serverTiming automatically.
+#
+# This runs in vcl_deliver, which executes at both the customer-facing edge POP
+# and the shield POP (the github-pages backend has a shield, so every origin
+# fetch is concentrated through iad-va-us). The two nodes can measure different
+# things, so each contributes the metric it can measure and the edge assembles
+# the final header:
+#
+#   origin;desc=<state>;dur=<ms>  the shield POP's total processing time, which
+#                                 is dominated by the fetch from GitHub Pages, so
+#                                 it stands in for the origin response time (near
+#                                 0 on a shield cache hit: the origin was not
+#                                 contacted for this request)
+#   edge;desc=<state>;dur=<ms>    total time this request spent inside the
+#                                 customer edge POP, which includes the wait on
+#                                 the backend when this request fetched through
+#
+# desc carries fastly_info.state (HIT, MISS, PASS, HIT-STALE, ...), so a reader
+# can tell whether a duration reflects real backend work or a cache serve. Those
+# values are Server-Timing token-safe, so desc is left unquoted.
+
+# req.http.Fastly-FF is present only on a node that received the request from
+# another Fastly node, which is the shield when the edge forwards to it. It is
+# the standard way to tell the shield POP from the customer-facing edge POP.
+if (req.http.Fastly-FF) {
+  # Shield POP. time.elapsed here is this node's total processing time, which is
+  # dominated by the fetch from GitHub Pages, so it stands in for the origin
+  # response time. time.to_first_byte would be the more literal choice but has no
+  # millisecond accessor and, in vcl_deliver, is within microseconds of
+  # time.elapsed anyway. Send it back to the edge as the origin metric.
+  set resp.http.Server-Timing = "origin;desc=" fastly_info.state ";dur=" time.elapsed.msec;
+} else if (obj.hits > 0) {
+  # Customer edge POP serving from its own cache. Any Server-Timing on the object
+  # is a stale artifact captured when the object was filled, not this request's
+  # backend timing, so discard it and report only this edge serve.
+  set resp.http.Server-Timing = "edge;desc=" fastly_info.state ";dur=" time.elapsed.msec;
+} else {
+  # Customer edge POP that fetched through to the shield on this request, so the
+  # origin metric forwarded from the shield describes this request. Preserve it
+  # (absent only if the shield snippet has not yet deployed) and append the edge
+  # total.
+  if (resp.http.Server-Timing) {
+    set resp.http.Server-Timing = resp.http.Server-Timing ", ";
+  }
+  set resp.http.Server-Timing = resp.http.Server-Timing "edge;desc=" fastly_info.state ";dur=" time.elapsed.msec;
+}

--- a/infra/fastly/snippets/server-timing-deliver.vcl
+++ b/infra/fastly/snippets/server-timing-deliver.vcl
@@ -1,51 +1,90 @@
-# Emit a Server-Timing header so the browser can see how long the backend took
-# versus the edge. The RUM bundle reads the parsed metrics from the navigation
-# PerformanceEntry (entry.serverTiming) and attaches them to the OpenTelemetry
-# document-fetch span (see assets/rum/index.js). Server-Timing is exposed to
-# same-origin script with no Timing-Allow-Origin needed, and the site is
-# same-origin, so the browser populates entry.serverTiming automatically.
+# Emit a Server-Timing header so the browser can attribute server-side latency.
+# The RUM bundle reads the parsed metrics from the navigation PerformanceEntry
+# (entry.serverTiming) and attaches them to the OpenTelemetry document-fetch span
+# (see assets/rum/index.js). Server-Timing is exposed to same-origin script with
+# no Timing-Allow-Origin needed, and the site is same-origin, so the browser
+# populates entry.serverTiming automatically.
 #
-# This runs in vcl_deliver, which executes at both the customer-facing edge POP
-# and the shield POP (the github-pages backend has a shield, so every origin
-# fetch is concentrated through iad-va-us). The two nodes can measure different
-# things, so each contributes the metric it can measure and the edge assembles
-# the final header:
+# Each metric name here is a FIELD name, not the node that measured it. The RUM
+# maps them generically (desc becomes fastly.<name>, dur becomes
+# fastly.<name>_ms), so the names chosen below are the attribute names that land
+# in Honeycomb and a new field needs no JavaScript change. The browser surfaces
+# only name, desc and dur from each metric, so one field carries at most one
+# string and one number; a fact needing both is split across two fields. All
+# values emitted here are Server-Timing token-safe, so desc is left unquoted.
 #
-#   origin;desc=<state>;dur=<ms>  the shield POP's total processing time, which
-#                                 is dominated by the fetch from GitHub Pages, so
-#                                 it stands in for the origin response time (near
-#                                 0 on a shield cache hit: the origin was not
-#                                 contacted for this request)
-#   edge;desc=<state>;dur=<ms>    total time this request spent inside the
-#                                 customer edge POP, which includes the wait on
-#                                 the backend when this request fetched through
+#   pop;desc=<code>            customer-facing POP serving this visitor
+#   region;desc=<region>       that POP's region, a fixed 16-value list
+#   cache_status;desc=<state>  how deep into the stack the request went
+#   total;dur=<ms>             total time inside Fastly, receipt to response
+#   backend;dur=<ms>           time the shield spent fetching from GitHub Pages
 #
-# desc carries fastly_info.state (HIT, MISS, PASS, HIT-STALE, ...), so a reader
-# can tell whether a duration reflects real backend work or a cache serve. Those
-# values are Server-Timing token-safe, so desc is left unquoted.
+# Fastly's own overhead is total minus backend.
+#
+# vcl_deliver runs at both the customer-facing edge POP and the iad-va-us shield
+# POP (the github-pages backend is shielded, so every origin fetch is
+# concentrated through the shield). The two nodes can measure different things,
+# so the shield reports what only it can see and the edge assembles the final
+# header.
+
+declare local var.st_shield_state STRING;
+declare local var.st_cache_status STRING;
 
 # req.http.Fastly-FF is present only on a node that received the request from
 # another Fastly node, which is the shield when the edge forwards to it. It is
 # the standard way to tell the shield POP from the customer-facing edge POP.
 if (req.http.Fastly-FF) {
   # Shield POP. time.elapsed here is this node's total processing time, which is
-  # dominated by the fetch from GitHub Pages, so it stands in for the origin
+  # dominated by the fetch from GitHub Pages, so it stands in for the backend
   # response time. time.to_first_byte would be the more literal choice but has no
   # millisecond accessor and, in vcl_deliver, is within microseconds of
-  # time.elapsed anyway. Send it back to the edge as the origin metric.
-  set resp.http.Server-Timing = "origin;desc=" fastly_info.state ";dur=" time.elapsed.msec;
-} else if (obj.hits > 0) {
-  # Customer edge POP serving from its own cache. Any Server-Timing on the object
-  # is a stale artifact captured when the object was filled, not this request's
-  # backend timing, so discard it and report only this edge serve.
-  set resp.http.Server-Timing = "edge;desc=" fastly_info.state ";dur=" time.elapsed.msec;
+  # time.elapsed anyway. Fastly-Shield-State rides back to the edge so it can
+  # derive cache_status; the edge strips it before delivery.
+  set resp.http.Server-Timing = "backend;dur=" time.elapsed.msec;
+  set resp.http.Fastly-Shield-State = fastly_info.state;
 } else {
-  # Customer edge POP that fetched through to the shield on this request, so the
-  # origin metric forwarded from the shield describes this request. Preserve it
-  # (absent only if the shield snippet has not yet deployed) and append the edge
-  # total.
+  # Customer-facing edge POP. Read and strip the shield's internal header first
+  # so it cannot reach the client down any path below. The header is absent
+  # whenever no shield leg ran, so it is defaulted to the empty string rather
+  # than left NOT SET, which keeps the match below a plain string comparison.
+  set var.st_shield_state = if(
+    resp.http.Fastly-Shield-State,
+    resp.http.Fastly-Shield-State,
+    ""
+  );
+  unset resp.http.Fastly-Shield-State;
+
+  # cache_status is derived to a single value so one Honeycomb group-by answers
+  # "how deep did this request go". The tradeoff is that an edge state and a
+  # shield state cannot both be reported: an edge HIT-STALE served over a shield
+  # MISS collapses into the edge's own state.
+  if (obj.hits > 0) {
+    # This POP answered from its own cache, so the shield was never consulted on
+    # this request. Any backend metric or shield state stored alongside the
+    # object is a stale artifact of the fill, describing whichever request
+    # happened to populate the cache, so discard both.
+    unset resp.http.Server-Timing;
+    set var.st_cache_status = fastly_info.state;
+  } else if (var.st_shield_state ~ "^HIT") {
+    # Fetched through, but the shield answered from its own cache, so GitHub
+    # Pages was never contacted. A bare edge MISS would hide this.
+    set var.st_cache_status = "SHIELD_HIT";
+  } else {
+    # Fetched through to GitHub Pages (MISS), or uncacheable (PASS). This also
+    # covers the visitor whose nearest POP is the shield itself: Fastly skips the
+    # redundant hop there, so one node plays both roles, Fastly-FF is unset, and
+    # no backend metric exists even though the origin was contacted.
+    set var.st_cache_status = fastly_info.state;
+  }
+
+  # Preserve the shield's backend metric when it describes this request; the
+  # branches above have already dropped it when it does not.
   if (resp.http.Server-Timing) {
     set resp.http.Server-Timing = resp.http.Server-Timing ", ";
   }
-  set resp.http.Server-Timing = resp.http.Server-Timing "edge;desc=" fastly_info.state ";dur=" time.elapsed.msec;
+  set resp.http.Server-Timing = resp.http.Server-Timing
+    "pop;desc=" server.datacenter
+    ", region;desc=" server.region
+    ", cache_status;desc=" var.st_cache_status
+    ", total;dur=" time.elapsed.msec;
 }

--- a/tests/edge/server-timing.test.js
+++ b/tests/edge/server-timing.test.js
@@ -1,0 +1,70 @@
+// Server-Timing emitted by the edge.
+//
+// server-timing-deliver.vcl sets a Server-Timing header carrying backend and
+// edge processing time so the browser RUM can attribute latency (see
+// docs/edge-caching.md). The header is assembled at the customer edge POP: it
+// always contains an `edge` metric, and an `origin` metric whenever the request
+// fetched through the shield to GitHub Pages. These tests confirm the header is
+// present and well-formed on an HTML response.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { config } from "./config.js";
+import { request } from "./lib/curl.js";
+import { retry } from "./lib/retry.js";
+
+// One metric group looks like `edge;desc=HIT;dur=1.23`. Parse the header into a
+// map of name -> { desc, dur } so assertions read the value, not the position.
+function parseServerTiming(header) {
+  const metrics = {};
+  for (const group of header.split(",")) {
+    const parts = group.split(";").map(p => p.trim());
+    const name = parts[0];
+    if (!name) continue;
+    const entry = {};
+    for (const part of parts.slice(1)) {
+      const eq = part.indexOf("=");
+      if (eq < 0) continue;
+      entry[part.slice(0, eq).trim()] = part.slice(eq + 1).trim();
+    }
+    metrics[name] = entry;
+  }
+  return metrics;
+}
+
+test("HTML carries a Server-Timing header with an edge metric", async () => {
+  const res = await request(`${config.baseUrl}/`);
+  assert.equal(res.status, 200);
+  const header = res.headers["server-timing"];
+  assert.ok(header, "no Server-Timing header on the HTML response");
+
+  const metrics = parseServerTiming(header);
+  assert.ok(metrics.edge, `no edge metric in Server-Timing: ${header}`);
+  assert.ok(
+    /^\d+(\.\d+)?$/.test(metrics.edge.dur),
+    `edge dur is not numeric: ${header}`
+  );
+  assert.ok(metrics.edge.desc, `edge metric has no desc (state): ${header}`);
+});
+
+test("a cache miss reports the origin backend metric", async () => {
+  // Force an origin fill so the shield contributes the origin metric, then
+  // assert the edge forwarded it. A cache-busting query string keeps the object
+  // out of the edge cache; the HTML is not fingerprinted, so this is a plain
+  // uncached path. Retry to tolerate a brief post-deploy propagation window.
+  const metrics = await retry(async () => {
+    const bust = `cache-bust-${Date.now()}`;
+    const res = await request(`${config.baseUrl}/?${bust}`);
+    assert.equal(res.status, 200);
+    const header = res.headers["server-timing"] || "";
+    const parsed = parseServerTiming(header);
+    assert.ok(parsed.origin, `no origin metric in Server-Timing: ${header}`);
+    return parsed;
+  });
+
+  assert.ok(
+    /^\d+(\.\d+)?$/.test(metrics.origin.dur),
+    `origin dur is not numeric: ${JSON.stringify(metrics.origin)}`
+  );
+  assert.ok(metrics.origin.desc, "origin metric has no desc (state)");
+});

--- a/tests/edge/server-timing.test.js
+++ b/tests/edge/server-timing.test.js
@@ -1,11 +1,12 @@
 // Server-Timing emitted by the edge.
 //
-// server-timing-deliver.vcl sets a Server-Timing header carrying backend and
-// edge processing time so the browser RUM can attribute latency (see
-// docs/edge-caching.md). The header is assembled at the customer edge POP: it
-// always contains an `edge` metric, and an `origin` metric whenever the request
-// fetched through the shield to GitHub Pages. These tests confirm the header is
-// present and well-formed on an HTML response.
+// server-timing-deliver.vcl sets a Server-Timing header whose metric names are
+// field names (`pop`, `region`, `cache_status`, `total`, `backend`), which the
+// RUM bundle maps straight onto span attributes as `fastly.<name>` and
+// `fastly.<name>_ms` (see docs/edge-caching.md). The edge always emits the first
+// four; `backend` appears only when the request fetched through the shield to
+// GitHub Pages. These tests confirm the header is present and well-formed on an
+// HTML response, and that the shield's internal header never reaches the client.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -13,8 +14,9 @@ import { config } from "./config.js";
 import { request } from "./lib/curl.js";
 import { retry } from "./lib/retry.js";
 
-// One metric group looks like `edge;desc=HIT;dur=1.23`. Parse the header into a
-// map of name -> { desc, dur } so assertions read the value, not the position.
+// One metric group looks like `cache_status;desc=HIT` or `total;dur=1.23`. Parse
+// the header into a map of name -> { desc, dur } so assertions read the value,
+// not the position.
 function parseServerTiming(header) {
   const metrics = {};
   for (const group of header.split(",")) {
@@ -32,39 +34,86 @@ function parseServerTiming(header) {
   return metrics;
 }
 
-test("HTML carries a Server-Timing header with an edge metric", async () => {
+test("HTML carries the edge Server-Timing fields", async () => {
   const res = await request(`${config.baseUrl}/`);
   assert.equal(res.status, 200);
   const header = res.headers["server-timing"];
   assert.ok(header, "no Server-Timing header on the HTML response");
 
   const metrics = parseServerTiming(header);
-  assert.ok(metrics.edge, `no edge metric in Server-Timing: ${header}`);
+
+  assert.ok(metrics.total, `no total metric in Server-Timing: ${header}`);
   assert.ok(
-    /^\d+(\.\d+)?$/.test(metrics.edge.dur),
-    `edge dur is not numeric: ${header}`
+    /^\d+(\.\d+)?$/.test(metrics.total.dur),
+    `total dur is not numeric: ${header}`
   );
-  assert.ok(metrics.edge.desc, `edge metric has no desc (state): ${header}`);
+
+  // server.datacenter is the POP code and server.region is one of a fixed
+  // 16-value list, both token-safe so both are emitted unquoted.
+  assert.ok(
+    /^[A-Za-z0-9]+$/.test(metrics.pop?.desc || ""),
+    `pop desc is not a POP code: ${header}`
+  );
+  assert.ok(
+    /^[A-Za-z-]+$/.test(metrics.region?.desc || ""),
+    `region desc is not a region code: ${header}`
+  );
+  assert.ok(
+    metrics.cache_status?.desc,
+    `no cache_status in Server-Timing: ${header}`
+  );
 });
 
-test("a cache miss reports the origin backend metric", async () => {
-  // Force an origin fill so the shield contributes the origin metric, then
-  // assert the edge forwarded it. A cache-busting query string keeps the object
-  // out of the edge cache; the HTML is not fingerprinted, so this is a plain
-  // uncached path. Retry to tolerate a brief post-deploy propagation window.
+test("the shield's internal state header never reaches the client", async () => {
+  // The shield sends Fastly-Shield-State back to the edge so the edge can derive
+  // cache_status; the edge must strip it on every path.
+  const res = await request(`${config.baseUrl}/?bust=${Date.now()}`);
+  assert.equal(res.status, 200);
+  assert.equal(
+    res.headers["fastly-shield-state"],
+    undefined,
+    "Fastly-Shield-State leaked to the client"
+  );
+});
+
+test("a cache miss reports a non-HIT cache_status and backend timing", async () => {
+  // Force an origin fill so the request leaves the edge POP. A cache-busting
+  // query string keeps the object out of the edge cache; the HTML is not
+  // fingerprinted, so this is a plain uncached path. Retry to tolerate a brief
+  // post-deploy propagation window.
   const metrics = await retry(async () => {
     const bust = `cache-bust-${Date.now()}`;
     const res = await request(`${config.baseUrl}/?${bust}`);
     assert.equal(res.status, 200);
     const header = res.headers["server-timing"] || "";
     const parsed = parseServerTiming(header);
-    assert.ok(parsed.origin, `no origin metric in Server-Timing: ${header}`);
+    assert.ok(
+      parsed.cache_status?.desc,
+      `no cache_status in Server-Timing: ${header}`
+    );
+    assert.notEqual(
+      parsed.cache_status.desc,
+      "HIT",
+      `cache-busted request reported an edge HIT: ${header}`
+    );
     return parsed;
   });
 
-  assert.ok(
-    /^\d+(\.\d+)?$/.test(metrics.origin.dur),
-    `origin dur is not numeric: ${JSON.stringify(metrics.origin)}`
-  );
-  assert.ok(metrics.origin.desc, "origin metric has no desc (state)");
+  if (metrics.backend) {
+    assert.ok(
+      /^\d+(\.\d+)?$/.test(metrics.backend.dur),
+      `backend dur is not numeric: ${JSON.stringify(metrics.backend)}`
+    );
+  } else {
+    // Fastly skips the shield hop for a visitor whose nearest POP is already the
+    // shield, so a single node plays both roles and no backend metric exists
+    // even though the origin was contacted. That path cannot produce SHIELD_HIT,
+    // which is derived from a shield response the edge never received.
+    assert.notEqual(
+      metrics.cache_status.desc,
+      "SHIELD_HIT",
+      "SHIELD_HIT reported without a backend metric, so the shield leg ran but " +
+        "its timing was lost"
+    );
+  }
 });


### PR DESCRIPTION
## What

Expose the backend processing time at the Fastly edge as a `Server-Timing`
header, read it in the browser, and attach it to the OpenTelemetry RUM
(#45) so backend latency is queryable in Honeycomb next to the Web Vitals
and load traces.

## Why

RUM currently captures browser-side timing but has no visibility into how
much of a navigation was spent waiting on the backend versus served from
the edge cache. `Server-Timing` is the standard way to surface that, and
the browser parses it onto the navigation `PerformanceEntry` for free.

## How

**Edge (`infra/fastly/snippets/server-timing-deliver.vcl`, `vcl_deliver`)**

The `github-pages` backend is shielded through `iad-va-us`, so `vcl_deliver`
runs at two nodes. Each contributes the metric it can measure accurately and
the customer edge assembles the header:

| Metric   | Set by     | Meaning                                                                       |
| -------- | ---------- | ----------------------------------------------------------------------------- |
| `origin` | shield POP | the shield's total time (`time.elapsed`), dominated by the GitHub Pages fetch; near `0` on a shield hit |
| `edge`   | edge POP   | `time.elapsed`, total time in the customer edge POP, incl. the backend wait   |

- `req.http.Fastly-FF` distinguishes the shield from the customer edge
- `time.elapsed.msec` is used for both metrics: `time.to_first_byte` is the
  more literal origin measure but has no millisecond accessor, and per
  Fastly's docs it is within microseconds of `time.elapsed` in `vcl_deliver`
- `desc` carries `fastly_info.state` (`HIT`/`MISS`/`PASS`/...), so a cache
  serve is distinguishable from real backend work
- on an edge cache hit the request never reaches the shield, so only the
  `edge` metric is emitted and any `origin` value cached with the object is
  discarded rather than reported as a stale fill time

**Browser (`assets/rum/index.js`)**

The document-load auto-instrumentation gains an `applyCustomAttributesOnSpan.documentFetch`
hook that copies `entry.serverTiming` onto the document-fetch span as
`server_timing.<name>.{duration_ms,description}`. It iterates the metrics
generically, so adding a metric in the VCL needs no JS change. The header is
same-origin, so full durations are exposed with no `Timing-Allow-Origin`.

## Testing

- `tests/edge/server-timing.test.js`: asserts the `edge` metric is always
  present on HTML and that a cache-busting request adds the `origin` backend
  metric. Runs post-deploy via `edge-verify.yml` (not on this PR, since the
  header does not exist in production until the Fastly apply lands)
- `RUM_MODE=production node scripts/build-rum.mjs` bundles cleanly and the
  document-load instrumentation plus the new attribute code are present in
  the output
- prettier and eslint clean

Docs updated in `docs/edge-caching.md` (new section + verify-by-hand) and
`docs/edge-verification.md` (suite table row).

## Deploy note

Per repo convention this does not run Pulumi. `infra.yml` will `pulumi
preview` on this PR and `pulumi up` on merge to `main`. An infra-only change
does not trigger the Pages purge, so already-cached objects keep serving
without the header until they expire or are purged; a one-time `purge_all`
gives instant convergence.
