### PR TITLE
fix: drop (null) prefix from Server-Timing

### DIFF
--- a/infra/fastly/snippets/server-timing-deliver.vcl
+++ b/infra/fastly/snippets/server-timing-deliver.vcl
@@ -29,6 +29,7 @@
 
 declare local var.st_shield_state STRING;
 declare local var.st_cache_status STRING;
+declare local var.st_header STRING;
 
 # req.http.Fastly-FF is present only on a node that received the request from
 # another Fastly node, which is the shield when the edge forwards to it. It is
@@ -77,14 +78,21 @@ if (req.http.Fastly-FF) {
     set var.st_cache_status = fastly_info.state;
   }
 
-  # Preserve the shield's backend metric when it describes this request; the
-  # branches above have already dropped it when it does not.
-  if (resp.http.Server-Timing) {
-    set resp.http.Server-Timing = resp.http.Server-Timing ", ";
-  }
-  set resp.http.Server-Timing = resp.http.Server-Timing
-    "pop;desc=" server.datacenter
+  # Assemble the edge's own metrics in a local. Reading a NOT SET header inside
+  # a concatenation yields the literal string "(null)", and Server-Timing is
+  # unset on every path where no shield metric survives (an edge HIT above, and
+  # any synthetic response such as the apex redirect), so the header is never an
+  # operand here.
+  set var.st_header = "pop;desc=" server.datacenter
     ", region;desc=" server.region
     ", cache_status;desc=" var.st_cache_status
     ", total;dur=" time.elapsed.msec;
+
+  # Preserve the shield's backend metric when it describes this request; the
+  # branches above have already dropped it when it does not.
+  if (resp.http.Server-Timing) {
+    set var.st_header = resp.http.Server-Timing ", " var.st_header;
+  }
+
+  set resp.http.Server-Timing = var.st_header;
 }

--- a/tests/edge/server-timing.test.js
+++ b/tests/edge/server-timing.test.js
@@ -34,11 +34,27 @@ function parseServerTiming(header) {
   return metrics;
 }
 
+// An unset header read inside a VCL concatenation stringifies to the literal
+// "(null)", which fuses onto the first metric name and makes the RUM bundle
+// record the field under a `fastly.(null)pop` attribute instead of `fastly.pop`.
+// Every emitting path must start at a real metric name.
+function assertNoNullMetric(header) {
+  assert.ok(
+    !header.includes("(null)"),
+    `Server-Timing contains a stringified unset header: ${header}`
+  );
+  assert.ok(
+    /^[A-Za-z_][A-Za-z0-9_]*[;,]/.test(header),
+    `Server-Timing does not begin with a metric name: ${header}`
+  );
+}
+
 test("HTML carries the edge Server-Timing fields", async () => {
   const res = await request(`${config.baseUrl}/`);
   assert.equal(res.status, 200);
   const header = res.headers["server-timing"];
   assert.ok(header, "no Server-Timing header on the HTML response");
+  assertNoNullMetric(header);
 
   const metrics = parseServerTiming(header);
 
@@ -63,6 +79,46 @@ test("HTML carries the edge Server-Timing fields", async () => {
     `no cache_status in Server-Timing: ${header}`
   );
 });
+
+test("an edge cache hit emits a clean Server-Timing", async () => {
+  // The edge-HIT branch unsets the shield's backend metric because it describes
+  // whichever request filled the cache, leaving nothing for the edge metrics to
+  // append to. Warm the object, then assert the header the hit produces.
+  const header = await retry(async () => {
+    await request(`${config.baseUrl}/`);
+    const res = await request(`${config.baseUrl}/`);
+    assert.equal(res.status, 200);
+    const value = res.headers["server-timing"] || "";
+    const parsed = parseServerTiming(value);
+    assert.equal(
+      parsed.cache_status?.desc,
+      "HIT",
+      `expected an edge HIT to assert against, got: ${value}`
+    );
+    return value;
+  });
+
+  assertNoNullMetric(header);
+  const metrics = parseServerTiming(header);
+  assert.ok(metrics.pop?.desc, `no pop metric on an edge hit: ${header}`);
+  assert.equal(
+    metrics.backend,
+    undefined,
+    `edge hit carried a stale backend metric: ${header}`
+  );
+});
+
+test(
+  "the apex redirect emits a clean Server-Timing",
+  { skip: config.isWww ? false : "base host is not a www subdomain" },
+  async () => {
+    // The redirect is synthesised at the edge, so no shield leg ever runs and
+    // the header has no backend metric to build on.
+    const res = await request(`https://${config.apexHost}/`);
+    assert.equal(res.status, 301);
+    assertNoNullMetric(res.headers["server-timing"] || "");
+  }
+);
 
 test("the shield's internal state header never reaches the client", async () => {
   // The shield sends Fastly-Shield-State back to the edge so the edge can derive


### PR DESCRIPTION
The `Server-Timing` header on production begins with the literal string `(null)`:

```
server-timing: (null)pop;desc=CHI, region;desc=US-Central, cache_status;desc=HIT, total;dur=0
```

## Cause

`server-timing-deliver.vcl` built the header by concatenating `resp.http.Server-Timing` with the edge metrics:

```vcl
if (resp.http.Server-Timing) {
  set resp.http.Server-Timing = resp.http.Server-Timing ", ";
}
set resp.http.Server-Timing = resp.http.Server-Timing
  "pop;desc=" server.datacenter
  ...
```

The guard only adds the separator. The final `set` reads the header unconditionally, and VCL stringifies a NOT SET header inside a concatenation as `(null)`. Two paths reach it with the header unset:

* the edge-HIT branch, which unsets the shield backend metric because it describes whichever request filled the cache
* any synthetic response, such as the apex-to-www redirect, where no shield leg ever runs

A shield MISS was unaffected, which is why the bug was invisible on a cache-busted request.

## Impact

The RUM bundle maps each metric name straight onto a span attribute, so the fused prefix landed in Honeycomb as `fastly.(null)pop` rather than `fastly.pop`. The POP dimension was split across two attributes depending on cache state.

## Fix

Assemble the edge metrics in a local and prepend the shield metric only when it exists, so an unset header is never an operand.

## Verification

`tests/edge/server-timing.test.js` gains an `assertNoNullMetric` helper and two tests targeting the affected paths. Both fail against production today:

```
✖ an edge cache hit emits a clean Server-Timing
  Server-Timing contains a stringified unset header: (null)pop;desc=CHI, ..., cache_status;desc=HIT, total;dur=0
✖ the apex redirect emits a clean Server-Timing
  Server-Timing contains a stringified unset header: (null)pop;desc=CHI, ..., cache_status;desc=HIT-SYNTH, total;dur=0
```

The suite runs against the live edge, so these pass once Pulumi applies the snippet on merge.