### PR TITLE
test: match the HIT family in the edge hit check

### DIFF
--- a/tests/edge/server-timing.test.js
+++ b/tests/edge/server-timing.test.js
@@ -90,10 +90,14 @@ test("an edge cache hit emits a clean Server-Timing", async () => {
     assert.equal(res.status, 200);
     const value = res.headers["server-timing"] || "";
     const parsed = parseServerTiming(value);
-    assert.equal(
-      parsed.cache_status?.desc,
-      "HIT",
-      `expected an edge HIT to assert against, got: ${value}`
+    // fastly_info.state qualifies a hit with how it was served, so the edge
+    // reports HIT-CLUSTER when the POP's storage node held the object. Match the
+    // family, not one spelling. SHIELD_HIT is a literal this snippet derives for
+    // a hit at the shield, so it does not collide with this prefix.
+    assert.match(
+      parsed.cache_status?.desc || "",
+      /^HIT/,
+      `expected an edge hit to assert against, got: ${value}`
     );
     return value;
   });


### PR DESCRIPTION
Follow-up to #73.

`an edge cache hit emits a clean Server-Timing` warms the object and then asserts on the resulting header. The precondition compared `cache_status` for a bare `HIT`, but `fastly_info.state` qualifies a hit with how it was served and the edge reports `HIT-CLUSTER` when the POP storage node held the object, so the retry exhausted without ever finding a hit to assert against.

Match `/^HIT/` instead. `SHIELD_HIT` is a literal this snippet derives for a hit at the shield, so it does not collide with the prefix.

Full suite against production:

```
✔ HTML carries the edge Server-Timing fields
✔ an edge cache hit emits a clean Server-Timing
✔ the apex redirect emits a clean Server-Timing
✔ the shield's internal state header never reaches the client
✔ a cache miss reports a non-HIT cache_status and backend timing
ℹ tests 33  pass 32  fail 0  skipped 1
```