### PR TITLE
fix: pin build.js paths to the module

### DIFF
--- a/src/_data/build.js
+++ b/src/_data/build.js
@@ -1,15 +1,19 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 // Build metadata exposed to templates as the global `build` object. Eleventy
 // evaluates this once per build, so every page reflects the same timestamp,
 // version, and commit.
 
+// Paths resolve relative to this module, not the process working directory, so
+// importing build.js from anywhere (a test, a script) behaves identically to an
+// Eleventy build running from the repo root.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
 // package.json version is the stable, human-readable release marker.
-const pkg = JSON.parse(
-  readFileSync(join(process.cwd(), "package.json"), "utf8")
-);
+const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
 
 // Short commit SHA identifies the exact source a build came from. Prefer a CI
 // env var (GitHub Actions sets GITHUB_SHA); fall back to `git rev-parse` for
@@ -23,6 +27,7 @@ function shortSha() {
   }
   try {
     return execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: repoRoot,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();


### PR DESCRIPTION
## Summary

`src/_data/build.js` had two implicit dependencies on the process working directory:

- `package.json` was read from `join(process.cwd(), "package.json")`. Eleventy runs from the repo root so builds were correct, but importing the module from any other cwd threw `ENOENT` at module top level, before `shortSha()` ran. The deliberate "never let a missing SHA fail the build" fallback never got a chance to apply.
- `execFileSync("git", ["rev-parse", "--short", "HEAD"])` inherited the process cwd, so it reported the SHA of whatever repository the caller happened to be in.

Both now resolve from `import.meta.url`: a `repoRoot` constant feeds the `package.json` read and is passed as the explicit `execFileSync` cwd. The `GITHUB_SHA` -> `git rev-parse` -> `null` fallback order and the exported shape (`time`, `version`, `sha`, `environment`, `production`, `label`) are unchanged.

## Verification

`npm run build` emits `<meta name=build content="1.0.0 (af49772)">` in `public/index.html`, matching `git rev-parse --short HEAD` (`af49772`).

Importing the module directly, with `GITHUB_SHA`, `GITHUB_ACTIONS`, and `ELEVENTY_ENV` cleared unless noted:

| Scenario | Result |
| --- | --- |
| cwd is an empty temp directory | `sha: "af49772"`, `label: "1.0.0 (af49772)"`, no throw |
| cwd is an unrelated git repo at `9b4a699` | `sha: "af49772"`, so the SHA comes from this repo, not the caller's |
| `GITHUB_SHA=abcdef1234567890`, `GITHUB_ACTIONS=true` | `sha: "abcdef1"`, `environment: "production"`, `production: true` |
| module plus `package.json` copied to a directory with no `.git` | `sha: null`, `label: "1.0.0"` |

`npm run lint` and `npm run prettier:check` pass. `npm test` runs the post-deploy edge suite against the live site: 32 pass, 1 skipped, 0 fail. Those tests do not cover this change.

Closes #75