### PR TITLE
ci: bump actions/cache to v6 for Node 24

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,7 @@ jobs:
       # plus anything that changes the output: image options and the plugin
       # version.
       - name: Cache optimized images
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: public/img
           key: eleventy-img-${{ hashFiles('src/media/images/**', 'eleventy.config.js', 'package-lock.json') }}


### PR DESCRIPTION
`actions/cache@v4` runs on Node 20, which GitHub deprecated and now force-runs on Node 24, producing a warning annotation on every Pages build. v6 targets `node24` natively.

The `path` and `key` inputs used by the step are unchanged across v4 to v6, so this is a version bump with no behavior change to the image cache.

Audited every other action against its pinned ref: `checkout@v5`, `setup-node@v5`, and `deploy-pages@v5` declare `using: node24`, and `upload-pages-artifact@v5` is a composite pinned to `upload-artifact` v7.0.0, which is also `node24`. No Node 20 targets remain.

Closes #78