### PR TITLE
ci: restructure workflows for triggers and style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+# Lints, format-checks, unit-tests, and builds the site on pull requests and
+# pushes to main. The deploy workflow only builds on push to main, so without
+# this a broken build or failing unit test would first surface during deploy.
+# The checks run as ordered steps in one job, cheapest first, so a lint
+# failure exits early without paying for the build.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint and format check
+        run: npm run format:check
+
+      - name: Unit tests
+        run: npm run test:unit
+
+      # Structural build check. RUM_MODE is unset so the RUM bundle step is a
+      # no-op; the production build with RUM enabled happens in pages.yml.
+      - name: Build site
+        run: npm run build

--- a/.github/workflows/honeycomb.yml
+++ b/.github/workflows/honeycomb.yml
@@ -1,35 +1,42 @@
 name: Honeycomb infra (Pulumi)
 
+# Previews (on pull requests) and applies (on push to main / manual dispatch)
+# the Pulumi stack that manages Honeycomb resources. See infra/honeycomb/.
+
 on:
   push:
     branches: [main]
-    paths:
+    paths: &honeycomb-paths
       - "infra/honeycomb/**"
       - ".github/workflows/honeycomb.yml"
   pull_request:
-    paths:
-      - "infra/honeycomb/**"
-      - ".github/workflows/honeycomb.yml"
+    paths: *honeycomb-paths
   workflow_dispatch:
 
 permissions:
   contents: read
   pull-requests: write
 
+# Serialize Pulumi runs so a preview never interleaves with an in-flight up.
+# cancel-in-progress is false so an apply is allowed to finish rather than be
+# left half-applied by a newer run.
+concurrency:
+  group: pulumi-honeycomb
+  cancel-in-progress: false
+
 jobs:
-  pulumi:
+  # The provider needs the Honeycomb v2 Management Key pair. Until those
+  # repository secrets are set (see infra/honeycomb/README.md) there is nothing
+  # meaningful to preview or apply, so skip the pulumi job cleanly with a notice
+  # instead of failing every run during bootstrap. The check lives in its own
+  # job because a job-level `if` cannot read the secrets context directly.
+  creds:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: infra/honeycomb
+    outputs:
+      present: ${{ steps.creds.outputs.present }}
     steps:
-      # The provider needs the Honeycomb v2 Management Key pair. Until those
-      # repository secrets are set (see infra/honeycomb/README.md) there is
-      # nothing meaningful to preview or apply, so skip cleanly with a notice
-      # instead of failing every run during bootstrap.
       - name: Check for Honeycomb credentials
         id: creds
-        working-directory: .
         env:
           KEY_ID: ${{ secrets.HONEYCOMB_KEY_ID }}
           KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET }}
@@ -41,18 +48,25 @@ jobs:
             echo "::notice::Skipping Pulumi: HONEYCOMB_KEY_ID / HONEYCOMB_KEY_SECRET repository secrets are not set. See infra/honeycomb/README.md."
           fi
 
+  pulumi:
+    needs: creds
+    if: needs.creds.outputs.present == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra/honeycomb
+    steps:
       - name: Checkout code
-        if: steps.creds.outputs.present == 'true'
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        if: steps.creds.outputs.present == 'true'
         uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
 
+      # pulumi install needs the CLI before pulumi/actions runs, so install it
+      # here at the same pinned version the action uses.
       - name: Install Pulumi CLI
-        if: steps.creds.outputs.present == 'true'
         run: |
           curl -fsSL https://get.pulumi.com | sh -s -- --version 3.246.0
           echo "$HOME/.pulumi/bin" >> "$GITHUB_PATH"
@@ -60,12 +74,10 @@ jobs:
       # Regenerates the bridged Honeycomb SDK declared in Pulumi.yaml (sdks/ is
       # gitignored) and installs node dependencies. No Pulumi Cloud auth needed.
       - name: Pulumi install
-        if: steps.creds.outputs.present == 'true'
         run: pulumi install
 
       # preview on pull requests, up (apply) on push to main / manual dispatch
       - name: Pulumi ${{ github.event_name == 'pull_request' && 'preview' || 'up' }}
-        if: steps.creds.outputs.present == 'true'
         uses: pulumi/actions@v7
         with:
           command: ${{ github.event_name == 'pull_request' && 'preview' || 'up' }}

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,20 +1,28 @@
 name: Fastly infra (Pulumi)
 
+# Previews (on pull requests) and applies (on push to main / manual dispatch)
+# the Pulumi stack that manages the Fastly service. See infra/fastly/.
+
 on:
   push:
     branches: [main]
-    paths:
+    paths: &fastly-paths
       - "infra/fastly/**"
       - ".github/workflows/infra.yml"
   pull_request:
-    paths:
-      - "infra/fastly/**"
-      - ".github/workflows/infra.yml"
+    paths: *fastly-paths
   workflow_dispatch:
 
 permissions:
   contents: read
   pull-requests: write
+
+# Serialize Pulumi runs so a preview never interleaves with an in-flight up.
+# cancel-in-progress is false so an apply is allowed to finish rather than be
+# left half-applied by a newer run.
+concurrency:
+  group: pulumi-fastly
+  cancel-in-progress: false
 
 jobs:
   pulumi:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,14 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+    # Skip the deploy (and the Fastly full purge) for pushes that cannot
+    # affect the built site: infra deploys through its own workflows, and
+    # tests, docs, and local tooling never reach public/.
+    paths-ignore:
+      - "infra/**"
+      - "tests/**"
+      - "docs/**"
+      - "local/**"
   workflow_dispatch: # Allow manual triggering
 
 # Minimum permissions the official Pages deployment flow requires:


### PR DESCRIPTION
Review of the GHA structure per #77: triggers, dependency handling, and internal consistency.

## Changes

| File | Change |
|------|--------|
| `ci.yml` (new) | Runs `format:check`, `test:unit`, and `npm run build` as ordered steps in one job, cheapest first, on PRs, pushes to main, and dispatch. None of these ran in CI before; a broken build previously first surfaced during deploy |
| `honeycomb.yml` | Credentials check moved to a `creds` gate job; the `pulumi` job now carries one job-level `if` instead of six step-level conditions, dropping the pre-checkout `working-directory: .` hack. Adds header comment, path anchor, `pulumi-honeycomb` concurrency group |
| `infra.yml` | Path anchor, `pulumi-fastly` concurrency group, header comment; now structurally matches honeycomb.yml |
| `pages.yml` | `paths-ignore` for `infra/**`, `tests/**`, `docs/**`, `local/**` so pushes that cannot affect the built site skip the deploy and the Fastly full purge |

## Deliberately unchanged

- `rum-smoke.yml`: already the style baseline (its YAML anchor pattern is now used by the infra workflows); stays standalone because the Playwright Chromium install is heavy and correctly path-filtered
- `edge-verify.yml`: `workflow_run` gating on main success is correct, and it intentionally skips `npm ci`
- Merging the two Pulumi workflows was considered and rejected: workflow-level path filters cannot route per-job, so a merge would need in-job change detection, more machinery than two aligned files

## Verification

- `prettier --check .github/workflows/*.yml` passes; YAML anchors parse and resolve identically for push and pull_request
- Local run of the exact CI sequence: format check clean, 32/32 unit tests pass, Eleventy build writes 39 files with `RUM_MODE=off` skipping the RUM bundle as designed

Note: the `creds` job in honeycomb.yml now always runs (a few seconds of runner time) in exchange for a single clean skip of the pulumi job when secrets are absent, since job-level `if` cannot read the secrets context.

Closes #77
