### PR TITLE
chore(deps): apply in-range security patches

### DIFF
--- a/infra/fastly/package-lock.json
+++ b/infra/fastly/package-lock.json
@@ -1221,15 +1221,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-from": {
@@ -1746,9 +1746,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -2664,9 +2664,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/infra/fastly/package.json
+++ b/infra/fastly/package.json
@@ -24,6 +24,6 @@
     "typescript": "6.0.3"
   },
   "overrides": {
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.3.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -884,16 +884,16 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -2899,9 +2899,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3385,16 +3385,16 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
@@ -4058,9 +4058,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -4156,9 +4156,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "prettier": "3.8.4"
   },
   "overrides": {
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.3.0"
   }
 }


### PR DESCRIPTION
Applies every Dependabot fix that resolves inside an existing parent
dependency range, so no new lockfile overrides are needed. Rebased onto
`main` after #81 and #82 merged, with both lockfiles regenerated against
the post-merge dependency graph rather than conflict-resolved by hand.

## Alerts closed

| Package | Before | After | Lockfile | Alerts |
| --- | --- | --- | --- | --- |
| `brace-expansion` | 1.1.15 | 1.1.18 | root | 99 |
| `brace-expansion` | 5.0.6 | 5.0.9 | root | 87 |
| `js-yaml` | 4.2.0 | 4.3.0 | root | 97 |
| `linkify-it` | 5.0.1 | 5.0.2 | root | 90 |
| `brace-expansion` | 5.0.6 | 5.0.9 | infra/fastly | 101, 88 |
| `js-yaml` | 4.2.0 | 4.3.0 | infra/fastly | 98 |
| `tar` | 7.5.16 | 7.5.22 | infra/fastly | 100, 95, 94, 93, 92 |

`js-yaml` moves through the `overrides` block in both `package.json`
files. Everything else moves via `npm update` inside the ranges its
parents already declare.

Alert 86 (`protobufjs` 7.6.4 to 7.6.5 in infra) no longer appears in this
diff. The `@pulumi/pulumi` 3.255.0 bump in #81 already carried infra
`protobufjs` to 7.6.5, so the alert is closed on `main`.

## Rebase notes

The original branch was cut from `main` before #81 and #82. Rather than
merge-resolve two lockfiles, the branch was reset to the post-merge
`main`, the two `overrides` values were re-applied, and `npm install`
plus targeted `npm update` regenerated both lockfiles. The resulting diff
touches only the seven package entries above, leaving the `sharp` 0.35.3
and OpenTelemetry 2.x resolutions from #82 and #81 intact.

## Verification

Root:

- `npm run lint:check` passes
- `npm run prettier:check` passes
- `npm test` passes, 32 passed and 1 skipped, the skip is the
  pre-existing HTTP/3 test that needs a curl built with HTTP/3
- `npm run build` succeeds, 138 files written and 20 images optimized

infra/fastly:

- `npx tsc --noEmit` passes
- `npm run format:check` passes
- `npm audit` reports 0 vulnerabilities

`pulumi preview` was not run, since it needs credentials.

## Out of scope

Root `npm audit` still reports moderate findings under
`@honeycombio/opentelemetry-web` and `@opentelemetry/auto-instrumentations-web`,
plus a high finding in `liquidjs` under Eleventy. Dependabot has not
raised alerts for these, they are devDependencies only, and each needs a
semver-major upgrade. They predate this branch and are untouched by it.
