### PR TITLE
ci: configure Dependabot for both npm projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,83 @@
+# Dependabot configuration for tollmanz.com.
+#
+# Two npm projects are managed: the root Eleventy site and the Fastly Pulumi
+# program in infra/fastly. infra/honeycomb is deliberately absent because its
+# lockfile is gitignored and pins `file:sdks/honeycombio`, a tree that
+# `pulumi install` regenerates, so Dependabot cannot resolve it.
+#
+# Grouping is not cosmetic here. Both projects resolve to a single lockfile, so
+# one pull request per update means N branches that all rewrite the same file
+# and conflict with each other on merge. #83 collapsed 13 security alerts into
+# one in-range lockfile change; the ungrouped alternative was 13 conflicting
+# branches.
+#
+# docs/dependency-updates.md records the reasoning, including the repository
+# settings that live outside this file.
+
+version: 2
+
+updates:
+  # Root Eleventy site.
+  #
+  # Every dependency here is a devDependency by npm's reckoning, so no
+  # `prefix-development` is set: it would stamp `deps-dev` on every commit,
+  # including the ones that change bytes served to visitors.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Bundled into /js/rum.<hash>.js by scripts/build-rum.mjs and served to
+      # visitors when RUM_MODE is local or production. npm calls these
+      # development dependencies; the browser disagrees. Separated so the
+      # upgrade is reviewed on its own. .github/workflows/rum-smoke.yml
+      # triggers on package-lock.json, so this PR always runs the RUM smoke
+      # test in headless Chromium.
+      browser-runtime:
+        patterns:
+          - "@honeycombio/*"
+          - "@opentelemetry/*"
+
+      # Eleventy and its first-party plugins move together and break together.
+      eleventy:
+        patterns:
+          - "@11ty/*"
+
+      # Everything else: linting, formatting, minification, Playwright, and
+      # the template-time libraries. Build-time only.
+      build-tooling:
+        patterns:
+          - "*"
+
+      # One pull request for all patchable advisories in this lockfile.
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # Fastly edge configuration (Pulumi TypeScript). Runs from a laptop or from
+  # .github/workflows/infra.yml, never in a browser. Monthly because the
+  # provider SDKs are the only thing that moves and an unreviewed edge config
+  # change is worse than a slightly stale one.
+  - package-ecosystem: "npm"
+    directory: "/infra/fastly"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      pulumi:
+        patterns:
+          - "@pulumi/*"
+
+      infra-tooling:
+        patterns:
+          - "*"
+
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,6 @@ Reference documentation for tollmanz.com.
   content at the Fastly edge in front of GitHub Pages, and why
 - [edge-verification.md](edge-verification.md): the `tests/edge/` suite that
   verifies that contract against the live edge after every deploy
+- [dependency-updates.md](dependency-updates.md): how Dependabot is configured
+  for both npm projects, why the defaults were wrong, and the repository
+  settings that live outside the config file

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -1,0 +1,106 @@
+# Dependency updates
+
+How Dependabot is configured for this repository, why it deviates from the
+defaults, and the one setting that cannot live in version control.
+
+## What went wrong on the defaults
+
+Before `.github/dependabot.yml` existed, Dependabot ran entirely on GitHub
+defaults: no manifest configuration, `dependabot_security_updates` disabled, and
+GitHub's preset auto-triage rule "dismiss low-impact alerts for
+development-scoped dependencies" active.
+
+Two advisories were dismissed by that rule with `auto_dismissed_at` set and
+`dismissed_reason` null, meaning no person made the call:
+
+| Alert | Package               | Severity | Scope       | Auto-dismissed       |
+| ----- | --------------------- | -------- | ----------- | -------------------- |
+| 96    | `liquidjs`            | high     | development | 2026-07-28T09:30:25Z |
+| 85    | `@opentelemetry/core` | medium   | development | 2026-07-15T21:03:36Z |
+
+Neither appeared on the alerts page, so the remediation round in #81, #82, and
+#83 reported a clean board while both were live in `package-lock.json`. They
+surfaced only because `npm audit` was run by hand.
+
+The rule governs most of the traffic this repository sees: of 88 lifetime
+alerts, 76 were development-scoped and 12 runtime.
+
+## npm scope is not blast radius
+
+Every dependency in the root `package.json` is a devDependency. Two of them are
+not development-only in any meaningful sense:
+
+- `@honeycombio/opentelemetry-web` and `@opentelemetry/auto-instrumentations-web`
+  are imported by `assets/rum/index.js`, bundled by `scripts/build-rum.mjs` into
+  `/js/rum.<hash>.js`, and served to visitors by `head.njk` whenever `RUM_MODE`
+  is `local` or `production`
+- `liquidjs` is reached through `@11ty/eleventy` and genuinely runs at build
+  time, so a compromise costs a local build rather than a visitor
+
+The distinction drives the configuration. The browser-bound subset gets its own
+group so its upgrades are reviewed as browser changes, and the auto-triage
+preset must stay off because it cannot tell the two cases apart. Turning it off
+is a manual step; see "Settings that are not in this file" below.
+
+## Configuration in this repository
+
+`.github/dependabot.yml` covers both npm projects:
+
+| Project       | Directory       | Interval | Version-update groups                          |
+| ------------- | --------------- | -------- | ---------------------------------------------- |
+| Eleventy site | `/`             | weekly   | `browser-runtime`, `eleventy`, `build-tooling` |
+| Fastly Pulumi | `/infra/fastly` | monthly  | `pulumi`, `infra-tooling`                      |
+
+Each project also defines a `security` group with
+`applies-to: security-updates`, collapsing all patchable advisories in that
+lockfile into one pull request.
+
+Grouping is load-bearing rather than cosmetic. Each project resolves to a single
+lockfile, so one pull request per update produces N branches that all rewrite the
+same file and conflict with each other on merge. #83 collapsed 13 alerts into one
+in-range lockfile change; ungrouped, that would have been 13 mutually conflicting
+branches.
+
+Pull requests against the root project that touch `package-lock.json` trigger
+`.github/workflows/rum-smoke.yml`, which executes the built RUM bundle in
+headless Chromium. Browser-runtime upgrades are therefore smoke-tested before
+merge without any extra wiring.
+
+## Settings that are not in this file
+
+GitHub exposes no REST or GraphQL API for auto-triage rules, so the first item
+below is a manual toggle that has to be re-checked by hand.
+
+| Setting                                                                     | Required state | Where                                                       |
+| --------------------------------------------------------------------------- | -------------- | ----------------------------------------------------------- |
+| Preset rule "Dismiss low impact alerts for development-scoped dependencies" | off            | Settings > Advanced Security > Dependabot rules             |
+| Dependabot alerts                                                           | enabled        | `GET /repos/tollmanz/tollmanz.com/vulnerability-alerts`     |
+| Dependabot security updates                                                 | enabled        | `PUT /repos/tollmanz/tollmanz.com/automated-security-fixes` |
+
+Security updates are enabled because the `security` groups give them a workable
+shape. With them on, Dependabot opens a pull request for every open alert that
+has a patch, so patchable advisories arrive as work rather than as a page nobody
+visits.
+
+Verify the two API-backed settings with:
+
+```sh
+gh api repos/tollmanz/tollmanz.com/automated-security-fixes
+gh api -i repos/tollmanz/tollmanz.com/vulnerability-alerts | head -1
+```
+
+Verify the preset rule by checking that no alert carries `auto_dismissed_at`:
+
+```sh
+gh api repos/tollmanz/tollmanz.com/dependabot/alerts --paginate \
+  --jq '.[] | select(.auto_dismissed_at) | {number, package: .dependency.package.name}'
+```
+
+## What is deliberately not covered
+
+- `infra/honeycomb` has no committed lockfile and its `package.json` pins
+  `@pulumi/honeycombio` to `file:sdks/honeycombio`, a tree that
+  `pulumi install` regenerates from `Pulumi.yaml`. Dependabot cannot resolve
+  that path, so adding the directory would only produce failing update runs
+- the `github-actions` ecosystem is not managed here. Workflow action versions
+  are bumped by hand


### PR DESCRIPTION
Closes #86

## What changed

`.github/dependabot.yml` now covers the root Eleventy site (`/`) and the Fastly Pulumi program (`/infra/fastly`). `docs/dependency-updates.md` records the reasoning and the settings that live outside the file.

## Decisions

| Decision | Choice | Reason |
| --- | --- | --- |
| Dev-scope auto-triage preset | off | npm scope and blast radius disagree here; the rule cannot tell `@honeycombio/opentelemetry-web` (shipped to browsers) from `liquidjs` (build-time) |
| Manifest config | both npm projects | `infra/honeycomb` excluded: gitignored lockfile pinning a regenerated `file:sdks/honeycombio` path |
| `dependabot_security_updates` | enabled | already applied via `PUT /repos/tollmanz/tollmanz.com/automated-security-fixes` |
| Security-update grouping | one `security` group per project | each project resolves to a single lockfile; #83 collapsed 13 alerts into one in-range change, and 13 separate branches would have conflicted |

Version updates are split into `browser-runtime`, `eleventy`, and `build-tooling` for the root project and `pulumi`, `infra-tooling` for infra. The browser-runtime group exists so RUM dependency bumps get reviewed as browser changes; `rum-smoke.yml` already triggers on `package-lock.json`, so those PRs run the headless Chromium smoke test.

## Action required after merge

GitHub exposes no REST or GraphQL API for auto-triage rules, so the preset has to be turned off by hand:

Settings > Advanced Security > Dependabot rules > uncheck "Dismiss low impact alerts for development-scoped dependencies"

Until that is done, development-scoped alerts keep getting dismissed with no notification, and Dependabot will not open security PRs for them.

## Verification

- config validates against the SchemaStore `dependabot-2.0` schema
- `gh api repos/tollmanz/tollmanz.com/automated-security-fixes` returns `{"enabled":true,"paused":false}`
- `prettier@3.8.4 --check` passes on all three files