### PR TITLE
feat(honeycomb): Core Web Vitals triage board

### DIFF
--- a/assets/rum/index.js
+++ b/assets/rum/index.js
@@ -1,7 +1,4 @@
-import {
-  HoneycombWebSDK,
-  WebVitalsInstrumentation,
-} from "@honeycombio/opentelemetry-web";
+import { HoneycombWebSDK } from "@honeycombio/opentelemetry-web";
 import { getWebAutoInstrumentations } from "@opentelemetry/auto-instrumentations-web";
 
 // Build-time configuration, replaced by esbuild `define` (see
@@ -60,6 +57,14 @@ if (mode !== "off") {
     serviceName,
     sampleRate,
     skipOptionsValidation: true,
+    // Core Web Vitals are deliberately absent from this list.
+    // HoneycombWebSDK appends its own WebVitalsInstrumentation unless
+    // `webVitalsInstrumentationConfig.enabled` is false, so naming it here too
+    // registers two instances. Both observe the same web-vitals callbacks and
+    // both emit a span, which silently doubles every LCP/CLS/INP/FCP/TTFB
+    // event. P75 survives that (duplicating every sample preserves
+    // percentiles) but every COUNT does not, so rating breakdowns and
+    // per-page-view counts read 2x. Leave vitals to the SDK.
     instrumentations: [
       getWebAutoInstrumentations({
         "@opentelemetry/instrumentation-fetch": { ignoreUrls },
@@ -75,7 +80,6 @@ if (mode !== "off") {
           },
         },
       }),
-      new WebVitalsInstrumentation(),
     ],
   });
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,4 +36,13 @@ export default [
       globals: { ...globals.browser, process: "readonly" },
     },
   },
+  {
+    // RUM browser harness: Node code that also carries page.evaluate callbacks,
+    // whose bodies are serialized and run inside the browser, so they reference
+    // browser globals that never exist in this file's own scope.
+    files: ["tests/rum/lib/**/*.js"],
+    languageOptions: {
+      globals: { ...globals.node, ...globals.browser },
+    },
+  },
 ];

--- a/infra/honeycomb/README.md
+++ b/infra/honeycomb/README.md
@@ -26,7 +26,16 @@ Triggers and SLOs are intentionally omitted for now. Like boards they are v1
 resources, so they are a clean drop-in later using the same Configuration Key
 providers the board tier adds.
 
-## RUM boards
+## Boards
+
+Two boards are managed as code against the `tollmanz-com-web` dataset:
+
+| Board                        | Environments   | Question it answers                   |
+| ---------------------------- | -------------- | ------------------------------------- |
+| `Real User Monitoring (RUM)` | prod and local | What are the numbers                  |
+| `Core Web Vitals triage`     | prod only      | Which pages miss a threshold, and why |
+
+## RUM board
 
 The board tier (issue #59) manages the `Real User Monitoring (RUM)` board as
 code, one per environment, in two sections against the `tollmanz-com-web`
@@ -62,6 +71,94 @@ because the template was written for a generic web app rather than this one:
   document loads, and `COUNT_DISTINCT(session.id)` would return the same figure, so
   only the label was wrong
 
+## Core Web Vitals triage board
+
+`Core Web Vitals triage` answers the question the RUM board does not: which
+pages miss a Core Web Vitals threshold, and why. Seven sections, 22 query
+panels, a 7 day window throughout:
+
+| Section                     | Content                                                             |
+| --------------------------- | ------------------------------------------------------------------- |
+| 1. Which pages miss         | Offender table and rating mix per metric, by `page.route`           |
+| 2. Why LCP misses           | The four LCP phases per route, the LCP element, phase trend         |
+| 3. Why CLS misses           | `cls.largest_shift_target` (the element that moved), and load state |
+| 4. Why INP misses           | The three INP phases per route, and the interaction behind them     |
+| 5. Server time and delivery | TTFB phases, plus Fastly cache outcome and POP from `documentFetch` |
+| 6. Who is affected          | Vitals split by device type, network type, and browser              |
+| 7. Drill into one page view | Worst individual views, keyed by `session.id`                       |
+
+Four properties of this telemetry shape the design. All four were verified by
+running the built bundle in headless Chromium and reading the exported OTLP
+payload, and against the live prod schema.
+
+- **Every web vital is its own single-span trace.** `WebVitalsInstrumentation`
+  starts a span with no parent when the metric finalizes, long after
+  `documentLoad` ended, so LCP, CLS, INP, FCP and TTFB each land as a root span
+  in a trace of their own. One page view is spread across about six traces and
+  no trace waterfall contains all of it
+- **`session.id` is the join key.** The SDK mints it once per document with no
+  persistence, so on this multi-page site one session id is exactly one page
+  view, and it is stamped on every span in every one of those traces. Section 7
+  exists because of this: take a `session.id` from a table and query
+  `session.id = <id>` to get every span that page view produced
+- **`page.route` is on every span**, added by the SDK's
+  `BrowserAttributesSpanProcessor` on span start, so vitals break down per page
+- **Resource attributes are flattened onto every event** by Honeycomb, so
+  `device.type`, `network.effectiveType` and `browser.name` segment vitals for
+  free
+
+The one thing that does not compose: `fastly.*` exists only on `documentFetch`
+spans and `ttfb.*` only on `TTFB` spans. Honeycomb has no join and these are
+different spans in different traces, so edge cache outcome cannot be broken down
+by TTFB in one query. Section 5 keeps them as neighbouring panels instead.
+
+Panels filter on `<metric>.rating` rather than a hand-written millisecond
+threshold, so Google's boundaries cannot drift out of sync here. It also
+sidesteps a data bug: `cls.value` was an `integer` column in prod for a while
+and truncated every score to zero, but `cls.rating` is computed in the browser
+from the true float and is correct across that period.
+
+Panels count page views with `COUNT_DISTINCT(session.id)`, not spans. Every
+vital reports at most once per page view, so the two agree on correct data, but
+a span count reads 2x for any window reaching back before the duplicate
+instrumentation fix (see below).
+
+### This board is prod only
+
+Ten of the 33 columns its queries reference do not exist in
+`tollmanz-com-local`, and Honeycomb validates every column when a saved query is
+created, so building it there fails the apply. Seeding them would not help. The
+five `fastly.*` fields come from the Server-Timing header the Fastly edge emits
+and nothing local is behind Fastly, so they can never carry a real value; the
+five `inp.*` attribution fields need a qualifying user interaction that local
+browsing generally does not produce. The local board would be sections of
+permanently empty panels describing infrastructure that is not there.
+
+The triage board is therefore opt-in per environment: `rumBoard` builds it only
+when passed a `triageDescription`, and only the prod call site passes one.
+
+### Web vitals were recorded twice until 2026-08-07
+
+`HoneycombWebSDK` appends its own `WebVitalsInstrumentation` unless
+`webVitalsInstrumentationConfig.enabled` is false. `assets/rum/index.js` also
+named it in `instrumentations`, so two instances were registered, both observed
+the same web-vitals callbacks, and both emitted a span. Every LCP, CLS, INP, FCP
+and TTFB event was recorded twice.
+
+Nothing threw, and p75 was unaffected because duplicating every sample preserves
+percentiles, so the RUM board's vitals section stayed correct throughout. What
+was wrong is every count over a vital: the rating breakdowns and
+`Total Events by Type` on the RUM board read 2x for that period, and so does any
+span count on this board over a window reaching back into it.
+
+The duplicate registration is fixed, and
+`tests/rum/smoke.test.js` guards it: the bundle runs a full page-view lifecycle
+in headless Chromium and asserts exactly one `TTFB` span. Historical data is not
+retroactively fixable. Use `COUNT_DISTINCT(session.id)` when counting across the
+boundary.
+
+## Configuration keys
+
 Boards, queries, and query annotations are Honeycomb v1 API resources. They need
 a v1 Configuration Key scoped to one environment, not the v2 Management Key the
 rest of this project uses. Two constraints shape how the keys are supplied:
@@ -75,12 +172,13 @@ rest of this project uses. Two constraints shape how the keys are supplied:
   env var would let a local apply create a board and a CI apply without the key
   delete it
 
-Each environment has its own flag, config key, and board:
+Each environment has its own flag and config key. Both build the RUM board; only
+prod also builds the triage board:
 
-| Environment          | Flag               | Config key env var           | Board output      |
-| -------------------- | ------------------ | ---------------------------- | ----------------- |
-| `tollmanz-com`       | `manageProdBoard`  | `HONEYCOMB_CONFIG_KEY`       | `rumBoardIdProd`  |
-| `tollmanz-com-local` | `manageLocalBoard` | `HONEYCOMB_LOCAL_CONFIG_KEY` | `rumBoardIdLocal` |
+| Environment          | Flag               | Config key env var           | Board outputs                      |
+| -------------------- | ------------------ | ---------------------------- | ---------------------------------- |
+| `tollmanz-com`       | `manageProdBoard`  | `HONEYCOMB_CONFIG_KEY`       | `rumBoardIdProd`, `cwvBoardIdProd` |
+| `tollmanz-com-local` | `manageLocalBoard` | `HONEYCOMB_LOCAL_CONFIG_KEY` | `rumBoardIdLocal`                  |
 
 Prerequisite: every column the board queries must already exist in the target
 environment, because Honeycomb validates columns when a saved query is created

--- a/infra/honeycomb/index.ts
+++ b/infra/honeycomb/index.ts
@@ -300,6 +300,506 @@ const overview = [
   },
 ];
 
+// ---------------------------------------------------------------------------
+// Core Web Vitals triage board (a second board, alongside the RUM one above)
+// ---------------------------------------------------------------------------
+//
+// The RUM board answers "what are the numbers". This one answers "which pages
+// miss a threshold, and why". Four facts about the shape of this telemetry
+// drive its design; all four were verified against the built bundle running in
+// headless Chromium and against the live prod schema.
+//
+// 1. Every web vital is its own single-span trace. WebVitalsInstrumentation
+//    calls `tracer.startSpan` with no parent when the metric finalizes, which
+//    is long after documentLoad ended, so LCP, CLS, INP, FCP and TTFB each land
+//    as a root span in their own trace. One page view is therefore scattered
+//    across roughly six traces and no trace waterfall shows the whole thing.
+//
+// 2. `session.id` is the join key that stitches them back together. The SDK
+//    mints it once per document with no persistence, so on this multi-page
+//    static site one session id is exactly one page view. It is stamped on
+//    every span, in every one of those traces. That is what makes the drill-down
+//    section work.
+//
+// 3. `page.route` is also on every span, added by the SDK's
+//    BrowserAttributesSpanProcessor on span start. Vitals can therefore be
+//    broken down per page, which is the whole basis of the offender tables.
+//
+// 4. Resource attributes (`device.type`, `network.effectiveType`,
+//    `browser.name`, `screen.size`, `entry_page.*`) are flattened onto every
+//    event by Honeycomb, so they segment vitals for free.
+//
+// The one thing that does not compose: `fastly.*` lives only on `documentFetch`
+// spans, and `ttfb.*` only on `TTFB` spans. Honeycomb has no join, and these
+// are different spans in different traces, so edge cache outcome cannot be
+// broken down by TTFB in a single query. The delivery section keeps them as
+// neighbouring panels and says so.
+//
+// Filters use `<metric>.rating` rather than a hand-written millisecond
+// threshold. The SDK computes the rating in the browser from Google's official
+// good/needs-improvement/poor boundaries, so the thresholds cannot drift out of
+// sync here. It also sidesteps a data bug: `cls.value` was an integer column in
+// prod for a while and truncated every score to zero, but `cls.rating` was
+// computed client-side from the true float and is correct across that period.
+
+// Seven days, matching the window Google reports Core Web Vitals over and the
+// vitals section of the RUM board.
+const TRIAGE_WINDOW = 604800;
+// Hourly buckets over that window, for the panels that show a trend.
+const TRIAGE_GRANULARITY = 3600;
+
+// The spans for one metric. Span names are emitted uppercase; the lowercase
+// alternate matches what the RUM board's ported queries already allow for.
+const vitalSpans = (metric: string) => ({
+  column: "name",
+  op: "in",
+  value: [metric.toUpperCase(), metric],
+});
+
+// Views that miss the threshold: everything Google does not call "good", so
+// needs-improvement is included rather than waiting for outright failure.
+const missesThreshold = (metric: string) => ({
+  column: `${metric}.rating`,
+  op: "!=",
+  value: "good",
+});
+
+const documentFetchSpans = {
+  column: "name",
+  op: "=",
+  value: "documentFetch",
+};
+
+// Vitals panels count page views, not spans. Every web vital reports at most
+// once per page view, and one `session.id` is one page view (see note 2 above),
+// so COUNT_DISTINCT over it is the honest number for a panel whose label says
+// "views". Plain COUNT would also read high for any window reaching back before
+// 2026-08-07: the bundle registered WebVitalsInstrumentation twice until then
+// and emitted every vital as two identical spans, so a span count reports twice
+// the real traffic. COUNT_DISTINCT is immune to that, which keeps these panels
+// comparable across the fix instead of showing a phantom 50% drop on the day it
+// shipped.
+const PAGE_VIEWS = { op: "COUNT_DISTINCT", column: "session.id" };
+const BY_VIEWS = [
+  { column: "session.id", op: "COUNT_DISTINCT", order: "descending" },
+];
+
+// documentFetch spans are one per navigation and were never duplicated, so on
+// the delivery panels a plain span count is exactly the request count.
+const BY_COUNT = [{ op: "COUNT", order: "descending" }];
+
+interface TriagePanel {
+  key: string;
+  label: string;
+  description: string;
+  style: string;
+  position: { x: number; y: number; width: number; height: number };
+  query: Record<string, unknown>;
+}
+
+interface TriageSection {
+  heading: string;
+  panels: TriagePanel[];
+}
+
+// One offender table per metric: the routes serving views that miss the
+// threshold, ranked by how many. This is the "where do I start" panel.
+const offenders = (metric: string, label: string, x: number): TriagePanel => ({
+  key: `${metric}-offenders`,
+  label: `${label}: pages missing the threshold`,
+  description: `Routes ranked by how many page views rated needs-improvement or poor for ${label}, with the 75th percentile ${label} on those views`,
+  style: "table",
+  position: { x, y: 0, width: 4, height: 6 },
+  query: {
+    breakdowns: ["page.route"],
+    calculations: [PAGE_VIEWS, { op: "P75", column: `${metric}.value` }],
+    filters: [vitalSpans(metric), missesThreshold(metric)],
+    orders: BY_VIEWS,
+    limit: 100,
+    time_range: TRIAGE_WINDOW,
+  },
+});
+
+// The good/needs-improvement/poor split over time, so a regression shows up as
+// a change in mix rather than only as a percentile drift.
+const ratingMix = (metric: string, label: string, x: number): TriagePanel => ({
+  key: `${metric}-rating-mix`,
+  label: `${label}: rating mix`,
+  description: `Page views by ${label} rating over time, hourly`,
+  style: "combo",
+  position: { x, y: 6, width: 4, height: 5 },
+  query: {
+    granularity: TRIAGE_GRANULARITY,
+    breakdowns: [`${metric}.rating`],
+    calculations: [PAGE_VIEWS],
+    filters: [vitalSpans(metric)],
+    orders: BY_VIEWS,
+    time_range: TRIAGE_WINDOW,
+  },
+});
+
+// Segment failing views by an audience dimension. Every calculation is scoped
+// to vitals spans, and each P75 only sees the spans that carry that column, so
+// one query reports all four metrics per segment.
+const segment = (
+  key: string,
+  column: string,
+  label: string,
+  x: number
+): TriagePanel => ({
+  key: `by-${key}`,
+  label: `Vitals by ${label}`,
+  description: `p75 of each Core Web Vital, split by ${label}`,
+  style: "table",
+  position: { x, y: 0, width: 4, height: 5 },
+  query: {
+    breakdowns: [column],
+    calculations: [
+      PAGE_VIEWS,
+      { op: "P75", column: "lcp.value" },
+      { op: "P75", column: "cls.value" },
+      { op: "P75", column: "inp.value" },
+      { op: "P75", column: "ttfb.value" },
+    ],
+    filters: [
+      {
+        column: "name",
+        op: "in",
+        value: ["LCP", "CLS", "INP", "TTFB", "FCP"],
+      },
+    ],
+    orders: BY_VIEWS,
+    limit: 100,
+    time_range: TRIAGE_WINDOW,
+  },
+});
+
+// The worst individual page views for one metric. `session.id` is the page view
+// (see note 2 above), so each row is one visitor's load and the id is what you
+// filter on to pull up every span that page view produced.
+const worstViews = (metric: string, label: string, x: number): TriagePanel => ({
+  key: `worst-${metric}-views`,
+  label: `Worst page views by ${label}`,
+  description: `Individual page views that missed the ${label} threshold, worst first. Filter the dataset on a session.id from this table to see every span that page view produced`,
+  style: "table",
+  position: { x, y: 0, width: 4, height: 8 },
+  query: {
+    breakdowns: ["session.id", "page.route"],
+    calculations: [{ op: "MAX", column: `${metric}.value` }],
+    filters: [vitalSpans(metric), missesThreshold(metric)],
+    orders: [{ column: `${metric}.value`, op: "MAX", order: "descending" }],
+    limit: 50,
+    time_range: TRIAGE_WINDOW,
+  },
+});
+
+const triage: TriageSection[] = [
+  {
+    heading:
+      "## 1. Which pages miss a threshold\n\n" +
+      "Seven days. A view counts as missing when the browser rated it anything other than `good`: " +
+      "LCP over 2.5s, INP over 200ms, CLS over 0.1. Start with the route at the top of a table, " +
+      "then read the matching section below for why.",
+    panels: [
+      offenders("lcp", "LCP", 0),
+      offenders("cls", "CLS", 4),
+      offenders("inp", "INP", 8),
+      ratingMix("lcp", "LCP", 0),
+      ratingMix("cls", "CLS", 4),
+      ratingMix("inp", "INP", 8),
+    ],
+  },
+  {
+    heading:
+      "## 2. Why LCP misses\n\n" +
+      "LCP decomposes into four consecutive phases that sum to the metric: time to first byte, " +
+      "then the delay before the browser discovers the LCP resource, then downloading it, then " +
+      "rendering it. Whichever column dominates is the thing to fix, and each points somewhere " +
+      "different: TTFB at the edge or origin, resource load delay at markup and discovery order, " +
+      "load duration at the asset itself, render delay at blocking CSS or JavaScript. " +
+      "`lcp.element` names the actual DOM node the browser measured.",
+    panels: [
+      {
+        key: "lcp-phases",
+        label: "LCP phase breakdown on failing views",
+        description:
+          "For views that missed the LCP threshold, p75 of each LCP phase per route. The four phases sum to LCP, so the largest column is the bottleneck",
+        style: "table",
+        position: { x: 0, y: 0, width: 8, height: 6 },
+        query: {
+          breakdowns: ["page.route"],
+          calculations: [
+            PAGE_VIEWS,
+            { op: "P75", column: "lcp.value" },
+            { op: "P75", column: "lcp.time_to_first_byte" },
+            { op: "P75", column: "lcp.resource_load_delay" },
+            { op: "P75", column: "lcp.resource_load_duration" },
+            { op: "P75", column: "lcp.element_render_delay" },
+          ],
+          filters: [vitalSpans("lcp"), missesThreshold("lcp")],
+          orders: BY_VIEWS,
+          limit: 100,
+          time_range: TRIAGE_WINDOW,
+        },
+      },
+      {
+        key: "lcp-elements",
+        label: "Which element is the LCP element",
+        description:
+          "The DOM element the browser measured as largest contentful paint on views that missed the threshold",
+        style: "table",
+        position: { x: 8, y: 0, width: 4, height: 6 },
+        query: {
+          breakdowns: ["lcp.element"],
+          calculations: [PAGE_VIEWS, { op: "P75", column: "lcp.value" }],
+          filters: [vitalSpans("lcp"), missesThreshold("lcp")],
+          orders: BY_VIEWS,
+          limit: 100,
+          time_range: TRIAGE_WINDOW,
+        },
+      },
+      {
+        key: "lcp-phase-trend",
+        label: "LCP phases over time",
+        description:
+          "p75 of each LCP phase across all views, hourly. Shows which phase moved when LCP regresses",
+        style: "graph",
+        position: { x: 0, y: 6, width: 12, height: 4 },
+        query: {
+          granularity: TRIAGE_GRANULARITY,
+          calculations: [
+            { op: "P75", column: "lcp.time_to_first_byte" },
+            { op: "P75", column: "lcp.resource_load_delay" },
+            { op: "P75", column: "lcp.resource_load_duration" },
+            { op: "P75", column: "lcp.element_render_delay" },
+          ],
+          filters: [vitalSpans("lcp")],
+          time_range: TRIAGE_WINDOW,
+        },
+      },
+    ],
+  },
+  {
+    heading:
+      "## 3. Why CLS misses\n\n" +
+      "`cls.largest_shift_target` is the CSS selector of the element whose movement contributed " +
+      "the most to the score, which usually names the fix outright: an image without dimensions, " +
+      "a late-loading font, an injected banner. `cls.load_state` says whether the shift happened " +
+      "while the page was still loading or after it settled.",
+    panels: [
+      {
+        key: "cls-shift-targets",
+        label: "Elements causing the layout shift",
+        description:
+          "The element responsible for the largest layout shift on views that missed the CLS threshold, ranked by how many page views it affected",
+        style: "table",
+        position: { x: 0, y: 0, width: 8, height: 6 },
+        query: {
+          breakdowns: ["cls.largest_shift_target"],
+          calculations: [
+            PAGE_VIEWS,
+            { op: "P75", column: "cls.value" },
+            { op: "MAX", column: "cls.largest_shift_value" },
+          ],
+          filters: [vitalSpans("cls"), missesThreshold("cls")],
+          orders: BY_VIEWS,
+          limit: 100,
+          time_range: TRIAGE_WINDOW,
+        },
+      },
+      {
+        key: "cls-load-state",
+        label: "When the shift happens",
+        description:
+          "Page lifecycle state at the moment of the largest shift, on views that missed the CLS threshold",
+        style: "table",
+        position: { x: 8, y: 0, width: 4, height: 6 },
+        query: {
+          breakdowns: ["cls.load_state"],
+          calculations: [PAGE_VIEWS, { op: "P75", column: "cls.value" }],
+          filters: [vitalSpans("cls"), missesThreshold("cls")],
+          orders: BY_VIEWS,
+          limit: 100,
+          time_range: TRIAGE_WINDOW,
+        },
+      },
+    ],
+  },
+  {
+    heading:
+      "## 4. Why INP misses\n\n" +
+      "INP is the sum of three phases: input delay while the main thread is busy before the " +
+      "handler runs, processing duration inside the handler, and presentation delay before the " +
+      "next frame paints. A large input delay means something else was blocking; a large " +
+      "processing duration means the handler itself is slow. `inp.element` and `inp.event_type` " +
+      "identify the interaction.",
+    panels: [
+      {
+        key: "inp-phases",
+        label: "INP phase breakdown on failing views",
+        description:
+          "For views that missed the INP threshold, p75 of each INP phase per route. The three phases sum to INP",
+        style: "table",
+        position: { x: 0, y: 0, width: 8, height: 6 },
+        query: {
+          breakdowns: ["page.route"],
+          calculations: [
+            PAGE_VIEWS,
+            { op: "P75", column: "inp.value" },
+            { op: "P75", column: "inp.input_delay" },
+            { op: "P75", column: "inp.processing_duration" },
+            { op: "P75", column: "inp.presentation_delay" },
+          ],
+          filters: [vitalSpans("inp"), missesThreshold("inp")],
+          orders: BY_VIEWS,
+          limit: 100,
+          time_range: TRIAGE_WINDOW,
+        },
+      },
+      {
+        key: "inp-interactions",
+        label: "Which interactions are slow",
+        description:
+          "The element and event type behind interactions that missed the INP threshold",
+        style: "table",
+        position: { x: 8, y: 0, width: 4, height: 6 },
+        query: {
+          breakdowns: ["inp.element", "inp.event_type"],
+          calculations: [PAGE_VIEWS, { op: "P75", column: "inp.value" }],
+          filters: [vitalSpans("inp"), missesThreshold("inp")],
+          orders: BY_VIEWS,
+          limit: 100,
+          time_range: TRIAGE_WINDOW,
+        },
+      },
+    ],
+  },
+  {
+    heading:
+      "## 5. Server time and edge delivery\n\n" +
+      "TTFB is the floor under LCP: no page can paint before its first byte arrives. The left " +
+      "panel decomposes TTFB as the browser measured it. The right two come from the Fastly " +
+      "Server-Timing header on the `documentFetch` span, which is a different span in a " +
+      "different trace, so Honeycomb cannot break one down by the other. Read them side by " +
+      "side: a route with poor TTFB and a `MISS` or `SHIELD_HIT` cache status is an edge caching " +
+      "problem, not an application one. `fastly.backend_ms` is absent whenever the edge answered " +
+      "from its own cache, which is the honest signal that no backend work happened.",
+    panels: [
+      {
+        key: "ttfb-phases",
+        label: "TTFB phase breakdown by route",
+        description:
+          "p75 of each phase the browser attributes time to before the first byte: DNS, connection, request, and waiting",
+        style: "table",
+        position: { x: 0, y: 0, width: 6, height: 6 },
+        query: {
+          breakdowns: ["page.route"],
+          calculations: [
+            PAGE_VIEWS,
+            { op: "P75", column: "ttfb.value" },
+            { op: "P75", column: "ttfb.dns_duration" },
+            { op: "P75", column: "ttfb.connection_duration" },
+            { op: "P75", column: "ttfb.request_duration" },
+            { op: "P75", column: "ttfb.waiting_duration" },
+          ],
+          filters: [vitalSpans("ttfb")],
+          orders: [{ column: "ttfb.value", op: "P75", order: "descending" }],
+          limit: 100,
+          time_range: TRIAGE_WINDOW,
+        },
+      },
+      {
+        key: "edge-cache-status",
+        label: "Navigation time by edge cache outcome",
+        description:
+          "How deep into the stack the navigation request went, and what it cost. Measured on the documentFetch span from the Fastly Server-Timing header",
+        style: "table",
+        position: { x: 6, y: 0, width: 6, height: 6 },
+        query: {
+          breakdowns: ["fastly.cache_status"],
+          calculations: [
+            { op: "COUNT" },
+            { op: "P75", column: "duration_ms" },
+            { op: "P75", column: "fastly.total_ms" },
+            { op: "P75", column: "fastly.backend_ms" },
+          ],
+          filters: [documentFetchSpans],
+          orders: BY_COUNT,
+          limit: 100,
+          time_range: TRIAGE_WINDOW,
+        },
+      },
+      {
+        key: "edge-pop",
+        label: "Navigation time by Fastly POP",
+        description:
+          "Navigation request duration per customer-facing POP, slowest first. Isolates a regional edge problem from a site-wide one",
+        style: "table",
+        position: { x: 0, y: 6, width: 12, height: 5 },
+        query: {
+          breakdowns: ["fastly.pop", "fastly.region"],
+          calculations: [
+            { op: "COUNT" },
+            { op: "P75", column: "duration_ms" },
+            { op: "P75", column: "fastly.total_ms" },
+          ],
+          filters: [documentFetchSpans],
+          orders: [{ column: "duration_ms", op: "P75", order: "descending" }],
+          limit: 100,
+          time_range: TRIAGE_WINDOW,
+        },
+      },
+    ],
+  },
+  {
+    heading:
+      "## 6. Who is affected\n\n" +
+      "The same vitals split by audience, from resource attributes Honeycomb flattens onto every " +
+      "event. A metric that only misses on `mobile`, on `3g`, or in one browser is a different " +
+      "problem from one that misses everywhere, and it changes what is worth fixing.",
+    panels: [
+      segment("device", "device.type", "device type", 0),
+      segment("network", "network.effectiveType", "network type", 4),
+      segment("browser", "browser.name", "browser", 8),
+    ],
+  },
+  {
+    heading:
+      "## 7. Drill into one page view\n\n" +
+      "Each web vital finalizes long after `documentLoad` ended, so the SDK emits it as a root " +
+      "span in its own trace. One page view is therefore spread across about six traces and no " +
+      "single waterfall contains all of it. `session.id` is what puts it back together: the SDK " +
+      "mints one per document, so on this site one session id is exactly one page view, and it " +
+      "is stamped on every span in every one of those traces.\n\n" +
+      "**To investigate a bad view:** pick a `session.id` from a table below, then run " +
+      "`session.id = <that id>` over the dataset with no breakdown. That returns every span the " +
+      "page view produced, the vitals and the load waterfall together, with each vital's full " +
+      "attribution attached. The left panel is different: those rows are `documentLoad` spans, " +
+      "so opening one goes straight to a real trace waterfall of the navigation and its " +
+      "subresources.",
+    panels: [
+      {
+        key: "slowest-page-loads",
+        label: "Slowest page loads (opens a trace)",
+        description:
+          "Individual documentLoad spans, slowest first. These are real traces: open one for the navigation and subresource waterfall",
+        style: "table",
+        position: { x: 0, y: 0, width: 4, height: 8 },
+        query: {
+          breakdowns: ["session.id", "page.route"],
+          calculations: [{ op: "MAX", column: "duration_ms" }],
+          filters: [{ column: "name", op: "=", value: "documentLoad" }],
+          orders: [{ column: "duration_ms", op: "MAX", order: "descending" }],
+          limit: 50,
+          time_range: TRIAGE_WINDOW,
+        },
+      },
+      worstViews("lcp", "LCP", 4),
+      worstViews("cls", "CLS", 8),
+    ],
+  },
+];
+
 // Honeycomb lays boards out on a 12 column grid. The vitals sit three to a row
 // under their heading, then the ported overview section starts below them, so
 // each section reads as its own block.
@@ -313,20 +813,35 @@ const OVERVIEW_HEADING_Y =
   VITALS_ORIGIN_Y + Math.ceil(vitals.length / VITALS_PER_ROW) * VITAL_HEIGHT;
 const OVERVIEW_ORIGIN_Y = OVERVIEW_HEADING_Y + HEADING_HEIGHT;
 
-// Build a curated RUM board in one environment, authenticated with that
+// The boards one environment gets. Every environment gets the RUM board; only
+// an environment whose dataset carries the full attribution schema gets the
+// triage board, so `triageBoardId` is absent for the local environment.
+interface EnvironmentBoards {
+  rumBoardId: pulumi.Output<string>;
+  triageBoardId?: pulumi.Output<string>;
+}
+
+// Build both curated boards for one environment, authenticated with that
 // environment's v1 Configuration Key. `slug` (prod/local) keeps resource names
-// unique across the two boards.
+// unique across the two environments. One provider serves both boards.
 //
-// This is now the only RUM board in each environment. The hand-made template
-// board that Honeycomb created, also called `Real User Monitoring (RUM)`, was
-// deleted once its panels were reproduced in the overview section below, so the
-// name is free and there is one board per environment rather than two similar
-// ones.
+// `Real User Monitoring (RUM)` is now the only RUM board in each environment.
+// The hand-made template board that Honeycomb created, also called `Real User
+// Monitoring (RUM)`, was deleted once its panels were reproduced in the overview
+// section below, so the name is free and there is one board per environment
+// rather than two similar ones.
+//
+// `Core Web Vitals triage` is the second board, built from the `triage` sections
+// above. It is separate rather than another section on the RUM board because it
+// answers a different question and is read at a different time: the RUM board
+// is the standing view, this one is opened when a vital regresses.
 function rumBoard(
   slug: string,
   configKey: string,
-  description: string
-): pulumi.Output<string> {
+  description: string,
+  // Omit to skip the Core Web Vitals triage board for this environment.
+  triageDescription?: string
+): EnvironmentBoards {
   const provider = new honeycombio.Provider(`rum-${slug}-config`, {
     apiKey: configKey,
   });
@@ -438,7 +953,59 @@ function rumBoard(
     providerOpts
   );
 
-  return board.id;
+  // The triage board is opt-in per environment, and only prod opts in. Ten of
+  // the columns its queries reference do not exist in `tollmanz-com-local`, and
+  // Honeycomb validates every column when a saved query is created, so building
+  // it there fails the apply outright. Seeding the columns would not help: the
+  // five `fastly.*` fields come from the Server-Timing header the Fastly edge
+  // emits, and nothing in the local stack is behind Fastly, so they can never
+  // carry a real value. The five `inp.*` attribution fields need a qualifying
+  // user interaction that local browsing generally does not produce. Either way
+  // the local board would be sections of permanently empty panels describing
+  // infrastructure that is not there.
+  if (!triageDescription) {
+    return { rumBoardId: board.id };
+  }
+
+  // Sections stack vertically: a full-width heading, then that section's panels
+  // at their declared offsets, then the next heading below the tallest panel in
+  // the section. Sections therefore never need to know their own absolute
+  // position, and inserting one does not renumber the rest.
+  let y = 0;
+  const triagePanels = triage.flatMap(section => {
+    const sectionPanels = [
+      heading(y, section.heading),
+      ...section.panels.map(panel =>
+        queryPanel(
+          `cwv-${slug}-${panel.key}`,
+          panel.query,
+          panel.label,
+          panel.description,
+          panel.style,
+          {
+            ...panel.position,
+            y: y + HEADING_HEIGHT + panel.position.y,
+          }
+        )
+      ),
+    ];
+    y +=
+      HEADING_HEIGHT +
+      Math.max(...section.panels.map(p => p.position.y + p.position.height));
+    return sectionPanels;
+  });
+
+  const triageBoard = new honeycombio.FlexibleBoard(
+    `cwv-${slug}-board`,
+    {
+      name: "Core Web Vitals triage",
+      description: triageDescription,
+      panels: triagePanels,
+    },
+    providerOpts
+  );
+
+  return { rumBoardId: board.id, triageBoardId: triageBoard.id };
 }
 
 // Read a required config key, failing fast with an actionable message so a
@@ -453,20 +1020,23 @@ function requireConfigKey(envVar: string, flag: string): string {
   return key;
 }
 
-let prodBoardId: pulumi.Output<string> | undefined;
+let prodBoards: EnvironmentBoards | undefined;
 if (manageProdBoard) {
-  prodBoardId = rumBoard(
+  prodBoards = rumBoard(
     "prod",
     requireConfigKey("HONEYCOMB_CONFIG_KEY", "manageProdBoard"),
-    "Core Web Vitals and a RUM overview for tollmanz.com browser RUM. Managed by infra/honeycomb (Pulumi)."
+    "Core Web Vitals and a RUM overview for tollmanz.com browser RUM. Managed by infra/honeycomb (Pulumi).",
+    "Which pages miss a Core Web Vitals threshold, and why. Managed by infra/honeycomb (Pulumi)."
   );
 }
 
-let localBoardId: pulumi.Output<string> | undefined;
+let localBoards: EnvironmentBoards | undefined;
 if (manageLocalBoard) {
-  localBoardId = rumBoard(
+  localBoards = rumBoard(
     "local",
     requireConfigKey("HONEYCOMB_LOCAL_CONFIG_KEY", "manageLocalBoard"),
+    // No triage board here: the local dataset lacks the fastly.* and inp.*
+    // attribution columns its queries need. See rumBoard.
     "Core Web Vitals and a RUM overview for tollmanz.com browser RUM, local testing environment. Managed by infra/honeycomb (Pulumi)."
   );
 }
@@ -482,7 +1052,10 @@ export const localEnvironmentSlug = localEnvironment.slug;
 export const ingestKey = pulumi.secret(ingest.key);
 export const localIngestKey = pulumi.secret(localIngest.key);
 
-// IDs of the curated RUM boards, when managed. Each is undefined until its flag
-// is enabled with the matching v1 Configuration Key present.
-export const rumBoardIdProd = prodBoardId;
-export const rumBoardIdLocal = localBoardId;
+// IDs of the curated boards, when managed. Each RUM board id is undefined until
+// its environment's flag is enabled with the matching v1 Configuration Key
+// present. There is no local counterpart to the triage board id: only prod
+// builds that board (see rumBoard).
+export const rumBoardIdProd = prodBoards?.rumBoardId;
+export const rumBoardIdLocal = localBoards?.rumBoardId;
+export const cwvBoardIdProd = prodBoards?.triageBoardId;

--- a/tests/rum/lib/browser.js
+++ b/tests/rum/lib/browser.js
@@ -28,10 +28,20 @@ export const SERVER_TIMING =
   "cache_status;desc=MISS, total;dur=42.1";
 
 // Run `source` (a built IIFE bundle) in headless Chromium and collect any
-// uncaught page errors plus every OTLP trace export it attempts. Resolves once
-// a trace export is recorded or a page error is thrown, whichever comes first,
-// so a clean bundle and a broken one both return promptly.
-export async function runRumBundle(source, { timeoutMs = 20000 } = {}) {
+// uncaught page errors plus every OTLP trace export it attempts.
+//
+// By default this resolves once a trace export is recorded or a page error is
+// thrown, whichever comes first, so a clean bundle and a broken one both return
+// promptly.
+//
+// `settleMs` instead runs a whole page-view lifecycle: keep collecting for that
+// long, then mark the document hidden, which is what makes web-vitals finalize
+// and report. Core Web Vitals are only observable that way, since none of them
+// are flushed by the first export.
+export async function runRumBundle(
+  source,
+  { timeoutMs = 20000, settleMs = 0 } = {}
+) {
   const pageErrors = [];
   const traceRequests = [];
 
@@ -60,7 +70,7 @@ export async function runRumBundle(source, { timeoutMs = 20000 } = {}) {
         return route.fulfill({
           contentType: "text/html",
           headers: { "Server-Timing": SERVER_TIMING },
-          body: `<!doctype html><meta charset="utf-8"><title>rum smoke</title><script src="/rum.js"></script>`,
+          body: `<!doctype html><meta charset="utf-8"><title>rum smoke</title><script src="/rum.js"></script><h1>rum smoke</h1>`,
         });
       }
       if (url === `${ORIGIN}/rum.js`) {
@@ -72,7 +82,9 @@ export async function runRumBundle(source, { timeoutMs = 20000 } = {}) {
           method: route.request().method(),
           body: route.request().postData(),
         });
-        finish();
+        // In settle mode the run is timed, not export-driven: vitals arrive in
+        // later exports than this one, so finishing here would cut them off.
+        if (!settleMs) finish();
         return route.fulfill({
           status: 200,
           contentType: "application/json",
@@ -83,7 +95,23 @@ export async function runRumBundle(source, { timeoutMs = 20000 } = {}) {
     });
 
     await page.goto(`${ORIGIN}/`, { waitUntil: "load" });
-    await settled;
+
+    if (settleMs) {
+      await page.waitForTimeout(settleMs);
+      // web-vitals finalizes and reports each metric when the document becomes
+      // hidden. Chromium will not hide a page on request, so drive the state
+      // and the event the library listens for directly.
+      await page.evaluate(() => {
+        Object.defineProperty(document, "visibilityState", {
+          value: "hidden",
+          configurable: true,
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      await page.waitForTimeout(settleMs);
+    } else {
+      await settled;
+    }
 
     return { pageErrors, traceRequests };
   } finally {

--- a/tests/rum/smoke.test.js
+++ b/tests/rum/smoke.test.js
@@ -153,6 +153,38 @@ test("the built RUM bundle samples at RUM_SAMPLE_RATE", async () => {
   );
 });
 
+// HoneycombWebSDK appends its own WebVitalsInstrumentation unless
+// `webVitalsInstrumentationConfig.enabled` is false, so also naming it in
+// `instrumentations` registers two instances that both observe the same
+// web-vitals callbacks and both emit a span. Every Core Web Vital is then
+// recorded twice. Nothing throws, and P75 is unmoved because duplicating every
+// sample preserves percentiles, so the boards in infra/honeycomb keep looking
+// plausible while every COUNT over a vital reads 2x. Only the span count shows
+// it, and only after the metrics report.
+//
+// TTFB is the sentinel. A duplicated registration duplicates all five vitals
+// equally, and TTFB is the one that always reports: it comes off the navigation
+// timing entry rather than needing paint, layout shift, or user interaction.
+test("the built RUM bundle records each Core Web Vital exactly once", async () => {
+  const pageView = await runRumBundle(buildLocalBundle(), { settleMs: 2500 });
+  assert.deepEqual(
+    pageView.pageErrors,
+    [],
+    `bundle threw: ${pageView.pageErrors.join("; ")}`
+  );
+
+  const ttfb = exportedSpans(pageView.traceRequests).filter(
+    span => span.name === "TTFB"
+  );
+  assert.equal(
+    ttfb.length,
+    1,
+    `expected exactly one TTFB span, got ${ttfb.length}. More than one means ` +
+      `web vitals are registered twice: drop WebVitalsInstrumentation from ` +
+      `the instrumentations list in assets/rum/index.js and let the SDK add it.`
+  );
+});
+
 test("the harness catches a process reference leaking into a bundle", async () => {
   const leaky = await buildLeakyBundle();
   const { pageErrors } = await runRumBundle(leaky, { timeoutMs: 5000 });


### PR DESCRIPTION
Adds a Core Web Vitals triage board, and fixes a double-count bug found
while mapping the data it queries.

Both boards are already applied so they could be reviewed against real
traffic:

- prod: https://ui.honeycomb.io/tollmanz/environments/tollmanz-com/board/wzV77RdatB1
- local: https://ui.honeycomb.io/tollmanz-com-local/environments/tollmanz-com-local/board/bvPhToCrdww

## Web vitals were recorded twice

`HoneycombWebSDK` appends its own `WebVitalsInstrumentation` unless
`webVitalsInstrumentationConfig.enabled` is false. `assets/rum/index.js`
also named it in `instrumentations`, so two instances were registered,
both observed the same web-vitals callbacks, and both emitted a span.
Every LCP, CLS, INP, FCP and TTFB event was recorded twice.

Nothing threw, and p75 was unaffected because duplicating every sample
preserves percentiles, so the RUM board's vitals section stayed correct
the whole time. What was wrong is every count over a vital: the LCP and
CLS rating breakdowns and `Total Events by Type` read 2x.

Verified by running the built bundle in headless Chromium and reading
the exported OTLP payload. Two spans per metric before, one after.
`tests/rum/smoke.test.js` guards it and fails with `got 2` when the
duplicate registration is restored.

Historical data is not retroactively fixable, which is why the new board
counts `COUNT_DISTINCT(session.id)` rather than spans.

## The shape of this telemetry

Four things, all verified against the running bundle and the live prod
schema, and all documented in `infra/honeycomb/README.md`:

- **Every web vital is its own single-span trace.**
  `WebVitalsInstrumentation` starts a span with no parent when the
  metric finalizes, long after `documentLoad` ended. One page view is
  spread across about six traces and no waterfall contains all of it
- **`session.id` is the join key.** The SDK mints one per document with
  no persistence, so on this multi-page site one session id is exactly
  one page view, and it is on every span in all of those traces
- **`page.route` is on every span**, added by the SDK's
  `BrowserAttributesSpanProcessor`, so vitals break down per page
- **Resource attributes are flattened onto every event**, so
  `device.type`, `network.effectiveType` and `browser.name` segment
  vitals for free

Prod has 140 columns including full attribution. The old board used
almost none of it.

## The board

| Section | Content |
| --- | --- |
| 1. Which pages miss | Offender table and rating mix per metric, by `page.route` |
| 2. Why LCP misses | The four LCP phases that sum to the metric, the LCP element, phase trend |
| 3. Why CLS misses | `cls.largest_shift_target`, the element that actually moved |
| 4. Why INP misses | The three INP phases, and the interaction behind them |
| 5. Server and delivery | TTFB phases, plus Fastly cache outcome and POP |
| 6. Who is affected | Vitals split by device type, network type, browser |
| 7. Drill into one view | Worst individual page views, keyed by `session.id` |

Panels filter on `<metric>.rating` rather than hand-written millisecond
thresholds, so Google's boundaries cannot drift out of sync here. That
also sidesteps the period when `cls.value` was an `integer` column and
truncated every score to zero, since `cls.rating` is computed in the
browser from the true float.

`fastly.*` lives only on `documentFetch` spans and `ttfb.*` only on
`TTFB` spans. Honeycomb has no join and these are different spans in
different traces, so section 5 keeps them as neighbouring panels rather
than pretending they compose.

## Local builds it too, as a staging copy

Both environments build the board, so a change can be rehearsed in
`tollmanz-com-local` before it reaches prod. Prod has no users yet,
which makes editing it directly harmless today and careless once it has
them.

Ten of the 33 columns had never been seen by local ingest, and Honeycomb
validates every column when a saved query is created, so those queries
could not be created there. They are declared as `honeycombio.Column`
resources in `LOCAL_STAGING_COLUMNS`, typed to match prod.

Declaring a column is not seeding it. `POST /1/columns` creates the
column empty, so nothing fabricates telemetry and no panel shows
invented data: those sections render empty until real events arrive.
Seeding stays a separate deliberate act.

Pulumi cannot infer that a query depends on a column, since a query
names its columns inside an opaque JSON string, so the triage queries
carry an explicit `dependsOn`.

## Verification

- 33/33 referenced columns exist in both environments. Honeycomb rejects
  unknown columns at query creation, so every query being accepted
  independently proves each reference is valid
- Both boards identical: 29 panels, 22 query and 7 text, same layout
  extent, every grid row summing to 12 columns
- Local apply created 55 resources (10 columns, 22 queries, 22
  annotations, 1 board) with prod untouched
- `pulumi preview` reports 165 unchanged, no drift
- `npm test` 32 pass, `npm run test:rum` 6 pass, `npm run format:check`
  clean

Not verified: whether individual panels return rows. The v1
Configuration Key has `queries: false` on this plan, so no query could
be executed.

## Notes

The RUM fix does not take effect until the site is rebuilt and deployed.

Three columns have drifted in type between the environments, each typed
from whatever value ingest saw first: `inp.value` (local `float`, prod
`integer`), `ttfb.request_duration` (local `integer`, prod `float`), and
`cls.delta` (local `float`, prod `integer`). `float` is correct in all
three. None is used by either board, so they are documented rather than
changed here, but they do mean a query reading them can behave
differently in the two environments.
