### PR TITLE
fix: make edge TLS probes portable to macOS

### DIFF
--- a/tests/edge/lib/tls.js
+++ b/tests/edge/lib/tls.js
@@ -2,8 +2,8 @@
 //
 // These probe properties an HTTP client cannot observe: which protocol versions
 // the edge accepts, whether it resumes a prior session, and whether it accepts
-// TLS 1.3 0-RTT early data. openssl is present on GitHub-hosted runners and
-// macOS, and version 3.x supports -early_data.
+// TLS 1.3 0-RTT early data. OPENSSL_BIN can select a non-system executable;
+// this matters on macOS, where /usr/bin/openssl is LibreSSL.
 //
 // s_client is run with stdin set to /dev/null (stdio "ignore"). With an empty
 // stdin it sees EOF immediately, completes the handshake, prints its session
@@ -21,9 +21,9 @@ const TIMEOUT_MS = 20000;
 // s_client exits non-zero in ordinary flows (the peer closing the connection,
 // for one), so output is captured regardless of exit status and the caller
 // decides success from the handshake summary it parses.
-function openssl(args) {
+function openssl(args, env = process.env) {
   return new Promise(resolve => {
-    const child = spawn("openssl", args, {
+    const child = spawn(env.OPENSSL_BIN || "openssl", args, {
       stdio: ["ignore", "pipe", "pipe"],
     });
     let out = "";
@@ -40,6 +40,29 @@ function openssl(args) {
     child.on("close", done);
     child.on("error", done);
   });
+}
+
+export async function opensslCapabilities(env = process.env) {
+  const bin = env.OPENSSL_BIN || "openssl";
+  const [versionOutput, help] = await Promise.all([
+    openssl(["version"], env),
+    openssl(["s_client", "-help"], env),
+  ]);
+  const version = versionOutput.trim();
+  const isOpenSsl = /^OpenSSL\s/.test(version);
+  const supports = flag => new RegExp(`(^|\\s)${flag}(?=\\s|$)`).test(help);
+  const sessionResumption =
+    isOpenSsl &&
+    supports("-tls1_3") &&
+    supports("-sess_in") &&
+    supports("-sess_out");
+
+  return {
+    bin,
+    version,
+    sessionResumption,
+    earlyData: sessionResumption && supports("-early_data"),
+  };
 }
 
 function connect(host, ...extra) {

--- a/tests/edge/tls.test.js
+++ b/tests/edge/tls.test.js
@@ -8,7 +8,18 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { config } from "./config.js";
-import { handshake, sessionResumption, earlyData } from "./lib/tls.js";
+import {
+  handshake,
+  sessionResumption,
+  earlyData,
+  opensslCapabilities,
+} from "./lib/tls.js";
+
+const capabilities = await opensslCapabilities();
+const unsupported = probe =>
+  `${probe} requires an OpenSSL s_client with TLS 1.3 session-ticket support; ` +
+  `found ${capabilities.version || "no usable executable"} at ${capabilities.bin}. ` +
+  "Set OPENSSL_BIN to a compatible OpenSSL executable.";
 
 test("TLS 1.3 is supported", async () => {
   const res = await handshake(config.host, "-tls1_3");
@@ -22,7 +33,11 @@ test("TLS 1.2 is supported for broad client compatibility", async () => {
   assert.equal(res.protocol, "TLSv1.2");
 });
 
-test("the edge resumes a prior TLS session", async () => {
+test("the edge resumes a prior TLS session", async t => {
+  if (!capabilities.sessionResumption) {
+    t.skip(unsupported("TLS session resumption"));
+    return;
+  }
   const res = await sessionResumption(config.host);
   assert.ok(
     res.reused,
@@ -30,7 +45,11 @@ test("the edge resumes a prior TLS session", async () => {
   );
 });
 
-test("the edge accepts TLS 1.3 0-RTT early data", async () => {
+test("the edge accepts TLS 1.3 0-RTT early data", async t => {
+  if (!capabilities.earlyData) {
+    t.skip(unsupported("TLS 1.3 0-RTT early data"));
+    return;
+  }
   const res = await earlyData(config.host);
   assert.ok(
     res.maxEarlyData > 0,

--- a/tests/unit/edge-tls.test.js
+++ b/tests/unit/edge-tls.test.js
@@ -1,0 +1,72 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { opensslCapabilities } from "../edge/lib/tls.js";
+
+function fakeOpenSsl(version, help) {
+  const dir = mkdtempSync(join(tmpdir(), "fake-openssl-"));
+  const bin = join(dir, "openssl");
+  writeFileSync(
+    bin,
+    `#!/bin/sh
+if [ "$1" = "version" ]; then
+  printf '%s\\n' '${version}'
+else
+  printf '%s\\n' '${help}' >&2
+fi
+`
+  );
+  chmodSync(bin, 0o755);
+  return { bin, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+test("opensslCapabilities honors OPENSSL_BIN and detects supported probes", async () => {
+  const fake = fakeOpenSsl(
+    "OpenSSL 3.5.2 5 Aug 2025",
+    "-tls1_3 -sess_in -sess_out -early_data"
+  );
+
+  try {
+    const capabilities = await opensslCapabilities({ OPENSSL_BIN: fake.bin });
+    assert.deepEqual(capabilities, {
+      bin: fake.bin,
+      version: "OpenSSL 3.5.2 5 Aug 2025",
+      sessionResumption: true,
+      earlyData: true,
+    });
+  } finally {
+    fake.cleanup();
+  }
+});
+
+test("opensslCapabilities rejects LibreSSL for TLS 1.3 ticket probes", async () => {
+  const fake = fakeOpenSsl(
+    "LibreSSL 3.3.6",
+    "-tls1_3 -sess_in -sess_out -ign_eof"
+  );
+
+  try {
+    const capabilities = await opensslCapabilities({ OPENSSL_BIN: fake.bin });
+    assert.equal(capabilities.sessionResumption, false);
+    assert.equal(capabilities.earlyData, false);
+  } finally {
+    fake.cleanup();
+  }
+});
+
+test("opensslCapabilities disables only early data when its flag is missing", async () => {
+  const fake = fakeOpenSsl(
+    "OpenSSL 1.1.1w  11 Sep 2023",
+    "-tls1_3 -sess_in -sess_out"
+  );
+
+  try {
+    const capabilities = await opensslCapabilities({ OPENSSL_BIN: fake.bin });
+    assert.equal(capabilities.sessionResumption, true);
+    assert.equal(capabilities.earlyData, false);
+  } finally {
+    fake.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- honor `OPENSSL_BIN` so macOS developers can select Homebrew OpenSSL instead of the system LibreSSL binary
- inspect the selected executable's implementation and `s_client` flags before running TLS 1.3 session-ticket probes
- skip only session resumption and 0-RTT when local tooling cannot support them, while continuing to test TLS 1.2 and TLS 1.3 handshakes
- add unit coverage for supported OpenSSL, LibreSSL, and OpenSSL without `-early_data`

## Approach

The TLS helper now routes every invocation through `OPENSSL_BIN` when set, falling back to `openssl` on `PATH`. Before the edge tests run, it executes `openssl version` and `openssl s_client -help` and derives two independent capabilities:

1. **Session resumption** requires genuine OpenSSL plus `-tls1_3`, `-sess_in`, and `-sess_out`. Requiring the OpenSSL implementation prevents macOS LibreSSL from presenting nominal session-file flags as support for the TLS 1.3 ticket behavior this probe needs.
2. **0-RTT early data** additionally requires `-early_data`. This keeps capability handling granular: an OpenSSL build without early-data support can still run the resumption probe.

The edge suite checks those capabilities at startup. Unsupported probes call `t.skip()` with the detected binary/version and an `OPENSSL_BIN` remediation hint. The basic protocol probes remain unconditional, so a missing or unusable executable cannot silently remove all TLS coverage.

This leaves GitHub Actions unchanged: its compatible OpenSSL runs every probe. On macOS, `/usr/bin/openssl` produces two explicit tooling skips, while setting:

```sh
OPENSSL_BIN=/opt/homebrew/opt/openssl@3/bin/openssl npm run test:edge
```

runs and passes the complete TLS suite.

## Verification

- `npm run test`
- `npm run lint`
- `npm run build`
- `npm run format:check`
- system LibreSSL: TLS 1.2/1.3 pass; resumption and 0-RTT skip with an explanation
- Homebrew OpenSSL 3.6.2: all four TLS tests pass
- independent pre-commit review: approved with no blocking issues

Closes #105
